### PR TITLE
Print Eint instead of Edisp

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 option(WITH_API "Enable export of C-API" TRUE)
 option(WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" TRUE)
 option(WITH_TESTS "Enable compilation of unit tests" TRUE)
-if(NOT DEFINED "${PROJECT_NAME}-dependeny-method")
+if(NOT DEFINED "${PROJECT_NAME}-dependency-method")
   set(
     "${PROJECT_NAME}-dependency-method"
     "subproject" "cmake" "pkgconf" "fetch"

--- a/src/tblite/xtb/singlepoint.f90
+++ b/src/tblite/xtb/singlepoint.f90
@@ -142,7 +142,7 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
       call timer%push("interactions")
       call calc%interactions%update(mol, icache)
       call calc%interactions%get_engrad(mol, icache, eint, gradient, sigma)
-      if (prlevel > 1) print *, property("interaction energy", edisp, "Eh")
+      if (prlevel > 1) print *, property("interaction energy", eint, "Eh")
       energy = energy + eint
       call timer%pop
    end if


### PR DESCRIPTION
`edisp` was incorrectly passed as argument when printing the "interaction energy"