### PR TITLE
Allow a standalone compilation of Python bindings with meson

### DIFF
--- a/python/meson.build
+++ b/python/meson.build
@@ -17,10 +17,25 @@
 project(
   'tblite',
   'c',
+  version: '0.2.0',
+  license: 'LGPL-3.0-or-later',
+  meson_version: '>=0.57.2',
+  default_options: [
+    'buildtype=debugoptimized',
+  ],
 )
 install = true
 
-tblite_dep = dependency('tblite', version: '>=0.2.0')
+tblite_dep = dependency(
+  'tblite',
+  version: '>=@0@'.format(meson.project_version()),
+  fallback: ['tblite', 'tblite_dep'],
+  default_options: [
+    'default_library=static',
+    'api=true',
+    'python=false',
+  ],
+)
 tblite_header = files('..'/'include'/'tblite.h')
 
 subdir('tblite')

--- a/python/mesonpep517.toml
+++ b/python/mesonpep517.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["mesonpep517"]
+build-backend = "mesonpep517.buildapi"
+
+[tool.mesonpep517.metadata]
+author = "Sebastian Ehlert"
+author-email = "awvwgk@disroot.org"
+summary = "Python API of the tblite project"
+description-file = "README.rst"
+home-page = "https://tblite.readthedocs.io"
+requires = [
+   "cffi",
+   "numpy",
+]
+requires-python = ">=3.6"

--- a/python/tblite/meson.build
+++ b/python/tblite/meson.build
@@ -47,15 +47,10 @@ tblite_cffi_srcs = configure_file(
   output: '@BASENAME@.c',
 )
 
-# Actual generation of the Python extension, since the shared_module does not work
-# well with dependency objects, we will trick it by linking a whole static lib
+# Actual generation of the Python extension
 tblite_pyext = python.extension_module(
   '_libtblite',
-  link_whole: static_library(
-    '_libtblite',
-    tblite_cffi_srcs,
-    dependencies: [tblite_dep, python_dep],
-  ),
+  sources: tblite_cffi_srcs,
   dependencies: [tblite_dep, python_dep],
   install: install,
   subdir: 'tblite',


### PR DESCRIPTION
Should allow standalone build of Python bindings with

```
meson setup _build/ python/ --prefix=$PWD/_dist --libdir=lib
meson compile -C _build
meson install -C _build
```

Should produce a Python distribution in `_dist/lib/python*/site-packages/tblite`.