### PR TITLE
Add color support for command line interface and API bindings

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   "driver_param.f90"
   "driver_run.f90"
   "driver_tagdiff.f90"
+  "features.F90"
   "main.f90"
 )
 set_target_properties(

--- a/app/cli_help.f90
+++ b/app/cli_help.f90
@@ -69,6 +69,8 @@ module tblite_cli_help
       ""//nl//&
       "Options"//nl//&
       ""//nl//&
+      "      --color string      Support colorful terminal output,"//nl//&
+      "                          possible values are never (default), always, auto."//nl//&
       help_text_general//nl//&
       ""//nl//&
       help_text_response

--- a/app/features.F90
+++ b/app/features.F90
@@ -1,0 +1,55 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+module tblite_features
+   implicit none
+   private
+
+   public :: get_tblite_feature
+
+
+contains
+
+function get_tblite_feature(feature) result(has_feature)
+   !> Feature name
+   character(len=*), intent(in) :: feature
+   !> Whether the feature is enabled
+   logical :: has_feature
+
+   select case(feature)
+   case("color")
+      has_feature = color_support()
+   case default
+      has_feature = .false.
+   end select
+end function get_tblite_feature
+
+!> Check output terminal for color support
+function color_support() result(color)
+   use, intrinsic :: iso_fortran_env, only : output_unit
+#if defined __INTEL_COMPILER
+   use ifport, only : isatty
+#endif
+   !> Whether color can be supported
+   logical :: color
+
+   color = .false.
+#if defined __GFORTRAN__ || defined __INTEL_COMPILER
+   color = isatty(output_unit)
+#endif
+end function color_support
+
+end module tblite_features

--- a/app/meson.build
+++ b/app/meson.build
@@ -25,6 +25,7 @@ tblite_exe = executable(
     'driver_param.f90',
     'driver_run.f90',
     'driver_tagdiff.f90',
+    'features.F90',
     'main.f90',
   ),
   dependencies: tblite_dep,
@@ -36,7 +37,7 @@ test('version', tblite_exe, args: '--version', suite: 'app')
 test('noargs', tblite_exe, should_fail: true, suite: 'app')
 test('fit-help', tblite_exe, args: ['fit', '--help'], suite: 'app')
 test('param-help', tblite_exe, args: ['param', '--help'], suite: 'app')
-test('run-help', tblite_exe, args: ['run', '--help'], suite: 'app')
+test('run-help', tblite_exe, args: ['--color', 'auto', 'run', '--help'], suite: 'app')
 test('tagdiff-help', tblite_exe, args: ['tagdiff', '--help'], suite: 'app')
 
 test(

--- a/fpm.toml
+++ b/fpm.toml
@@ -8,6 +8,7 @@ keywords = ["quantum-chemistry", "tight-binding", "xtb"]
 copyright = "Copyright 2021 S. Ehlert"
 
 [build]
+external-modules = ["ifport"]
 link = ["lapack", "blas"]
 auto-tests = false
 

--- a/include/tblite/context.h
+++ b/include/tblite/context.h
@@ -54,3 +54,8 @@ TBLITE_API_ENTRY void TBLITE_API_CALL
 tblite_set_context_logger(tblite_context /* ctx */,
                           tblite_logger_callback /* callback */,
                           void* /* userdata */);
+
+/// Enable colorful output
+TBLITE_API_ENTRY void TBLITE_API_CALL
+tblite_set_context_color(tblite_context /* ctx */,
+                         int /* color */);

--- a/man/tblite.1.adoc
+++ b/man/tblite.1.adoc
@@ -32,6 +32,10 @@ Main driver for tight-binding framework.
 
 == Options
 
+*--color* _string_::
+     Support colorful terminal output,
+     possible values are _never_ (default), _always_, and _auto_.
+
 *--version*::
      Prints version number and citation
 

--- a/python/tblite/library.py
+++ b/python/tblite/library.py
@@ -20,6 +20,7 @@ This module mainly acts as a guard for importing the libtblite extension and
 also provides some FFI based wappers for memory handling.
 """
 
+import sys
 import functools
 import numpy as np
 
@@ -104,10 +105,12 @@ def _delete_context(context) -> None:
     lib.tblite_delete_context(ptr)
 
 
-def new_context():
+def new_context(color: bool = True):
     """Create new tblite context handler object"""
     ctx = ffi.gc(lib.tblite_new_context(), _delete_context)
     context_check(lib.tblite_set_context_logger)(ctx, lib.logger_callback, ffi.NULL)
+    if color and sys.stdout.isatty():
+        context_check(lib.tblite_set_context_color)(ctx, 1)
     return ctx
 
 

--- a/src/tblite/api/context.f90
+++ b/src/tblite/api/context.f90
@@ -18,8 +18,7 @@
 module tblite_api_context
    use, intrinsic :: iso_c_binding
    use mctc_env, only : error_type, fatal_error
-   use tblite_context_logger, only : context_logger
-   use tblite_context_type, only : context_type
+   use tblite_context, only : context_type, context_logger, context_terminal
    use tblite_api_error, only : vp_error
    use tblite_api_version, only : namespace
    use tblite_api_utils, only : f_c_character
@@ -133,6 +132,22 @@ subroutine get_context_error_api(vctx, charptr, buffersize) &
    end if
 
 end subroutine get_context_error_api
+
+
+subroutine set_context_color_api(vctx, color) &
+      & bind(C, name=namespace//"set_context_color")
+   type(c_ptr), value :: vctx
+   type(vp_context), pointer :: ctx
+   integer(c_int), value :: color
+
+   if (debug) print '("[Info]", 1x, a)', "set_context_color"
+
+   if (c_associated(vctx)) then
+      call c_f_pointer(vctx, ctx)
+
+      ctx%ptr%terminal = context_terminal(color /= 0)
+   end if
+end subroutine set_context_color_api
 
 
 !> Delete context object

--- a/src/tblite/context.f90
+++ b/src/tblite/context.f90
@@ -38,8 +38,19 @@
 !> It provides a [[context_logger:message]] procedure which is used by the context
 !> to create output. This type can be used to create callbacks for customizing or
 !> redirecting the output of the library, e.g. when used from C or Python.
+!>
+!> ANSI escape sequences are available via the [[context_terminal]] class and which is
+!> instantiated in the [[context_type:terminal]] member. The terminal instance provides
+!> access to various terminal formatting codes to produce the respective ANSI escape
+!> sequences if the terminal is created with color support, otherwise return empty strings.
+!> Detecting whether the terminal supports ANSI escape sequences is left as excerise to
+!> the consumer of the [[context_terminal]] class.
+!>
+!> For convenience operators are provided to add escape codes as well as concatenate
+!> them directly with strings.
 module tblite_context
    use tblite_context_logger, only : context_logger
+   use tblite_context_terminal, only : context_terminal, escape, operator(+), operator(//)
    use tblite_context_type, only : context_type
    implicit none
    public

--- a/src/tblite/context/CMakeLists.txt
+++ b/src/tblite/context/CMakeLists.txt
@@ -19,6 +19,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 list(
   APPEND srcs
   "${dir}/logger.f90"
+  "${dir}/terminal.f90"
   "${dir}/type.f90"
 )
 

--- a/src/tblite/context/meson.build
+++ b/src/tblite/context/meson.build
@@ -16,5 +16,6 @@
 
 srcs += files(
   'logger.f90',
+  'terminal.f90',
   'type.f90',
 )

--- a/src/tblite/context/terminal.f90
+++ b/src/tblite/context/terminal.f90
@@ -1,0 +1,239 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> Support for ANSI escape sequences to get colorful terminal output
+module tblite_context_terminal
+   use mctc_env, only : i1
+   implicit none
+   private
+
+   public :: context_terminal, escape, operator(+), operator(//)
+
+   !> Container for terminal escape code
+   type :: color
+      !> Style descriptor
+      integer(i1) :: style = -1_i1
+      !> Background color descriptor
+      integer(i1) :: bg = -1_i1
+      !> Foreground color descriptor
+      integer(i1) :: fg = -1_i1
+   end type
+
+   interface operator(+)
+      module procedure :: add
+   end interface operator(+)
+
+   interface operator(//)
+      module procedure :: concat_left
+      module procedure :: concat_right
+   end interface operator(//)
+
+   type(color), parameter :: &
+      reset = color(style=0_i1), &
+      bold = color(style=1_i1), &
+      dim = color(style=2_i1), &
+      italic = color(style=3_i1), &
+      underline = color(style=4_i1), &
+      blink = color(style=5_i1), &
+      reverse = color(style=7_i1), &
+      hidden = color(style=8_i1)
+
+   type(color), parameter :: &
+      black = color(fg=0_i1), &
+      red = color(fg=1_i1), &
+      green = color(fg=2_i1), &
+      yellow = color(fg=3_i1), &
+      blue = color(fg=4_i1), &
+      magenta = color(fg=5_i1), &
+      cyan = color(fg=6_i1), &
+      white = color(fg=7_i1)
+
+   type(color), parameter :: &
+      bg_black = color(bg=0_i1), &
+      bg_red = color(bg=1_i1), &
+      bg_green = color(bg=2_i1), &
+      bg_yellow = color(bg=3_i1), &
+      bg_blue = color(bg=4_i1), &
+      bg_magenta = color(bg=5_i1), &
+      bg_cyan = color(bg=6_i1), &
+      bg_white = color(bg=7_i1)
+
+
+   !> Colorizer class for handling colorful output in the terminal
+   type :: context_terminal
+
+      type(color) :: &
+         reset = color(), &
+         bold = color(), &
+         dim = color(), &
+         italic = color(), &
+         underline = color(), &
+         blink = color(), &
+         reverse = color(), &
+         hidden = color()
+
+      type(color) :: &
+         black = color(), &
+         red = color(), &
+         green = color(), &
+         yellow = color(), &
+         blue = color(), &
+         magenta = color(), &
+         cyan = color(), &
+         white = color()
+
+      type(color) :: &
+         bg_black = color(), &
+         bg_red = color(), &
+         bg_green = color(), &
+         bg_yellow = color(), &
+         bg_blue = color(), &
+         bg_magenta = color(), &
+         bg_cyan = color(), &
+         bg_white = color()
+
+      type(color) :: &
+         bold_black = color(), &
+         bold_red = color(), &
+         bold_green = color(), &
+         bold_yellow = color(), &
+         bold_blue = color(), &
+         bold_magenta = color(), &
+         bold_cyan = color(), &
+         bold_white = color()
+   end type context_terminal
+
+   !> Constructor for the colorizer
+   interface context_terminal
+      module procedure :: new_terminal
+   end interface context_terminal
+
+contains
+
+
+!> Create a new colorizer object
+function new_terminal(use_color) result(new)
+   !> Enable color output
+   logical, intent(in) :: use_color
+   !> New instance of the colorizer
+   type(context_terminal) :: new
+
+   if (use_color) then
+      new%reset = reset
+      new%bold = bold
+      new%dim = dim
+      new%italic = italic
+      new%underline = underline
+      new%blink = blink
+      new%reverse = reverse
+      new%hidden = hidden
+      new%black = black
+      new%red = red
+      new%green = green
+      new%yellow = yellow
+      new%blue = blue
+      new%magenta = magenta
+      new%cyan = cyan
+      new%white = white
+      new%bg_black = bg_black
+      new%bg_red = bg_red
+      new%bg_green = bg_green
+      new%bg_yellow = bg_yellow
+      new%bg_blue = bg_blue
+      new%bg_magenta = bg_magenta
+      new%bg_cyan = bg_cyan
+      new%bg_white = bg_white
+      new%bold_black = bold + black
+      new%bold_red = bold + red
+      new%bold_green = bold + green
+      new%bold_yellow = bold + yellow
+      new%bold_blue = bold + blue
+      new%bold_magenta = bold + magenta
+      new%bold_cyan = bold + cyan
+      new%bold_white = bold + white
+   end if
+end function new_terminal
+
+!> Add two escape sequences, attributes in the right value override the left value ones.
+pure function add(lval, rval) result(code)
+   !> First escape code
+   type(color), intent(in) :: lval
+   !> Second escape code
+   type(color), intent(in) :: rval
+   !> Combined escape code
+   type(color) :: code
+
+   code = color( &
+      style=merge(rval%style, lval%style, rval%style >= 0), &
+      fg=merge(rval%fg, lval%fg, rval%fg >= 0), &
+      bg=merge(rval%bg, lval%bg, rval%bg >= 0))
+end function add
+
+!> Concatenate an escape code with a string and turn it into an actual escape sequence
+pure function concat_left(lval, code) result(str)
+   !> String to add the escape code to
+   character(len=*), intent(in) :: lval
+   !> Escape sequence
+   type(color), intent(in) :: code
+   !> Concatenated string
+   character(len=:), allocatable :: str
+
+   str = lval // escape(code)
+end function concat_left
+
+!> Concatenate an escape code with a string and turn it into an actual escape sequence
+pure function concat_right(code, rval) result(str)
+   !> String to add the escape code to
+   character(len=*), intent(in) :: rval
+   !> Escape sequence
+   type(color), intent(in) :: code
+   !> Concatenated string
+   character(len=:), allocatable :: str
+
+   str = escape(code) // rval
+end function concat_right
+
+!> Transform a color code into an actual ANSI escape sequence
+pure function escape(code) result(str)
+   !> Color code to be used
+   type(color), intent(in) :: code
+   !> ANSI escape sequence representing the color code
+   character(len=:), allocatable :: str
+   character, parameter :: chars(0:9) = &
+      ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+   if (anycolor(code)) then
+      str = achar(27) // "[0"  ! Always reset the style
+      if (code%style > 0 .and. code%style < 10) str = str // ";" // chars(code%style)
+      if (code%fg >= 0 .and. code%fg < 10) str = str // ";3" // chars(code%fg)
+      if (code%bg >= 0 .and. code%bg < 10) str = str // ";4" // chars(code%bg)
+      str = str // "m"
+   else
+      str = ""
+   end if
+end function escape
+
+!> Check whether the code describes any color or is just a stub
+pure function anycolor(code)
+   !> Escape sequence
+   type(color), intent(in) :: code
+   !> Any color / style is active
+   logical :: anycolor
+
+   anycolor = code%fg >= 0 .or. code%bg >= 0 .or. code%style >= 0
+end function anycolor
+
+end module tblite_context_terminal

--- a/src/tblite/context/type.f90
+++ b/src/tblite/context/type.f90
@@ -19,6 +19,7 @@ module tblite_context_type
    use iso_fortran_env, only : output_unit
    use mctc_env, only : error_type
    use tblite_context_logger, only : context_logger
+   use tblite_context_terminal, only : context_terminal
    implicit none
    private
 
@@ -35,6 +36,8 @@ module tblite_context_type
       type(error_type), allocatable :: error_log(:)
       !> Optional logger to be used for writing messages
       class(context_logger), allocatable :: io
+      !> Color support for output
+      type(context_terminal) :: terminal = context_terminal()
    contains
       !> Write a message to the output
       procedure :: message

--- a/test/api/main.c
+++ b/test/api/main.c
@@ -778,6 +778,7 @@ test_callback (void)
 
    tblite_logger_callback callback = example_callback;
    tblite_set_context_logger(ctx, callback, NULL);
+   tblite_set_context_color(ctx, 1);
 
    mol = tblite_new_structure(
       error,
@@ -817,6 +818,7 @@ test_callback (void)
    if (!check(energy, -32.96247211794, thr, "energy error")) goto err;
 
    tblite_set_context_logger(ctx, NULL, NULL);
+   tblite_set_context_color(ctx, 0);
    tblite_set_calculator_max_iter(ctx, calc, 3);
 
    tblite_get_singlepoint(ctx, mol, calc, res);


### PR DESCRIPTION
Currently only used for highlighting convergence in SCF iterations.