### PR TITLE
Guard system headers from inclusion in CFFI processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,6 +319,11 @@ jobs:
         gcc_v: [10]
         python_v: ['3.7', '3.8', '3.9']
 
+        include:
+        - os: macos-latest
+          gcc_v: 9
+          python_v: '3.9'
+
     env:
       FC: gfortran
       CC: gcc
@@ -373,6 +378,7 @@ jobs:
       run: pytest --pyargs tblite --cov=tblite -vv
       env:
         LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}:${{ env.TBLITE_PREFIX }}/lib
+        DYLD_LIBRARY_PATH: ${{ env.DYLD_LIBRARY_PATH }}:${{ env.TBLITE_PREFIX }}/lib
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v2

--- a/include/tblite/macros.h
+++ b/include/tblite/macros.h
@@ -19,8 +19,14 @@
 
 #ifdef __cplusplus
 #define TBLITE_API_ENTRY extern "C"
+#ifndef TBLITE_CFFI
+#include <cstdint>
+#endif
 #else
 #define TBLITE_API_ENTRY extern
+#ifndef TBLITE_CFFI
 #include <stdbool.h>
+#include <stdint.h>
+#endif
 #endif
 #define TBLITE_API_CALL

--- a/include/tblite/table.h
+++ b/include/tblite/table.h
@@ -17,9 +17,6 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include "tblite/macros.h"
 #include "tblite/error.h"
 


### PR DESCRIPTION
Including the `stdint.h` on MacOS can lead to parsing errors, also the CFFI module should not export the system C library.