### PR TITLE
Add workflow for building wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,58 @@
+name: wheel
+
+on: [push, workflow_dispatch]
+
+jobs:
+  manylinux:
+    runs-on: ubuntu-latest
+    container: condaforge/linux-anvil-cos7-x86_64
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell || 'bash -l {0}' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        path: python/subprojects/tblite
+    - name: Create environment
+      run: >-
+        mamba create -n wheel
+        --yes
+        c-compiler
+        fortran-compiler
+        python=${{ matrix.python }}
+        auditwheel
+        git
+        python
+        pip
+        python-build
+        pkgconfig
+        patchelf
+        cffi
+        numpy
+        meson
+        unzip
+        wheel
+    - name: Build wheel
+      run: |
+        conda activate wheel
+        set -ex
+        cp {mesonpep517,pyproject}.toml
+        python -m build . --wheel
+        auditwheel show dist/*.whl
+        auditwheel repair -w dist dist/*.whl --plat ${{ env.plat }}
+        rm dist/*-linux_x86_64.whl
+      env:
+        plat: manylinux${{ matrix.python == '3.6' && '2010' || '_2_12' }}_x86_64
+      working-directory: python
+    - uses: actions/upload-artifact@v3
+      with:
+        name: tblite-python-${{ matrix.python }}
+        path: python/dist/*.whl
+        retention-days: 5

--- a/python/mesonpep517.toml
+++ b/python/mesonpep517.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["mesonpep517"]
+build-backend = "mesonpep517.buildapi"
+
+[tool.mesonpep517.metadata]
+author = "Sebastian Ehlert"
+author-email = "awvwgk@disroot.org"
+summary = "Light-weight tight-binding framework"
+description-file = "README.rst"
+home-page = "https://tblite.readthedocs.io"
+requires = [
+   "cffi",
+   "numpy",
+]
+requires-python = ">=3.6"


### PR DESCRIPTION
Could be useful for installing standalone Python bindings for *tblite*. Due to static linking and redistribution of OpenBLAS the wheels tend to be rather large (~16MB).