### PR TITLE
Build system maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ target_include_directories(
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${module-dir}>
 )
+if(NOT EXISTS "${PROJECT_BINARY_DIR}/include")
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/include")
+endif()
 
 # Add example application
 add_subdirectory("app")

--- a/config/cmake/tblite-utils.cmake
+++ b/config/cmake/tblite-utils.cmake
@@ -76,7 +76,7 @@ macro(
 
         # We need the module directory in the subproject before we finish the configure stage
         if(NOT EXISTS "${${_pkg_uc}_BINARY_DIR}/include")
-          make_directory("${${_pkg_uc}_BINARY_DIR}/include")
+          file(MAKE_DIRECTORY "${${_pkg_uc}_BINARY_DIR}/include")
         endif()
 
         break()
@@ -99,7 +99,7 @@ macro(
       # We need the module directory in the subproject before we finish the configure stage
       FetchContent_GetProperties("${_pkg_lc}" BINARY_DIR "${_pkg_uc}_BINARY_DIR")
       if(NOT EXISTS "${${_pkg_uc}_BINARY_DIR}/include")
-        make_directory("${${_pkg_uc}_BINARY_DIR}/include")
+        file(MAKE_DIRECTORY "${${_pkg_uc}_BINARY_DIR}/include")
       endif()
 
       break()

--- a/config/install-mod.py
+++ b/config/install-mod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This file is part of tblite.
 # SPDX-Identifier: LGPL-3.0-or-later
 #


### PR DESCRIPTION
- use python3 for installation of module files
- use `file(MAKE_DIRECTORY)` instead of `make_directory`
- create module directory in configure stage