### PR TITLE
Adjust docstrings for processing with doxygen

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -283,7 +283,7 @@ OPTIMIZE_OUTPUT_JAVA   = NO
 # sources. Doxygen will then generate output that is tailored for Fortran.
 # The default value is: NO.
 
-OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_FOR_FORTRAN   = YES
 
 # Set the OPTIMIZE_OUTPUT_VHDL tag to YES if your project consists of VHDL
 # sources. Doxygen will then generate output that is tailored for VHDL.
@@ -871,7 +871,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include/
+INPUT                  = ../include/ ../src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/api/c.rst
+++ b/doc/api/c.rst
@@ -22,25 +22,103 @@ Overall four classes of objects are provided by the library
 
    Generally, all quantities provided to the library are assumed to be in `atomic units <https://en.wikipedia.org/wiki/Hartree_atomic_units>`_.
 
+Main header
+-----------
+
+.. code:: c
+
+   #include "tblite.h"
 
 .. doxygenfile:: tblite.h
 
+
+Version query
+-------------
+
+.. code:: c
+
+   #include "tblite/version.h"
+
 .. doxygenfile:: tblite/version.h
+
+
+Macro definitions
+-----------------
+
+.. code:: c
+
+   #include "tblite/macros.h"
 
 .. doxygenfile:: tblite/macros.h
 
+Error handler
+-------------
+
+.. code:: c
+
+   #include "tblite/error.h"
+
 .. doxygenfile:: tblite/error.h
+
+Context handler
+---------------
+
+.. code:: c
+
+   #include "tblite/context.h"
 
 .. doxygenfile:: tblite/context.h
 
+Molecular structure data
+------------------------
+
+.. code:: c
+
+   #include "tblite/structure.h"
+
 .. doxygenfile:: tblite/structure.h
+
+Calculator instance
+-------------------
+
+.. code:: c
+
+   #include "tblite/calculator.h"
 
 .. doxygenfile:: tblite/calculator.h
 
+Interaction container
+---------------------
+
+.. code:: c
+
+   #include "tblite/container.h"
+
 .. doxygenfile:: tblite/container.h
+
+Result container
+----------------
+
+.. code:: c
+
+   #include "tblite/result.h"
 
 .. doxygenfile:: tblite/result.h
 
+Parametrization records
+-----------------------
+
+.. code:: c
+
+   #include "tblite/param.h"
+
 .. doxygenfile:: tblite/param.h
+
+Table data structure
+--------------------
+
+.. code:: c
+
+   #include "tblite/table.h"
 
 .. doxygenfile:: tblite/table.h

--- a/doc/api/c.rst
+++ b/doc/api/c.rst
@@ -3,7 +3,7 @@ C API
 
 The C API bindings are provided by using the ``iso_c_binding`` intrinsic module.
 Generally, objects are exported as opaque pointers and can only be manipulated within the library.
-The API user is required delete all objects created in the library by using the provided deconstructor functions to avoid mamory leaks.
+The API user is required delete all objects created in the library by using the provided deconstructor functions to avoid memory leaks.
 
 Overall four classes of objects are provided by the library
 

--- a/include/tblite.h
+++ b/include/tblite.h
@@ -15,7 +15,7 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/**@dir tblite
+/**@dir include/tblite
  * @brief
  * Collection of public API bindings for the tblite library.
  */

--- a/include/tblite.h
+++ b/include/tblite.h
@@ -15,14 +15,13 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite.h
- * C bindings for tblite
- * =====================
- *
- * ```
- * include "tblite.h"
- * ```
- *
+/**@dir tblite
+ * @brief
+ * Collection of public API bindings for the tblite library.
+ */
+
+/**@file tblite.h
+ * @brief
  * Provides convenience functionality for working with the C API bindings for tblite
  * by including all relevant headers and defining general type generic macros for
  * working with the object handles.
@@ -41,6 +40,8 @@
 #include "tblite/version.h"
 
 /// Generic macro to free an object handle.
+///
+/// @param ptr: Opaque object handle
 #define tblite_delete(ptr) _Generic((ptr), \
                        tblite_error: tblite_delete_error, \
                    tblite_container: tblite_delete_container, \

--- a/include/tblite/calculator.h
+++ b/include/tblite/calculator.h
@@ -15,13 +15,9 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/calculator.h
- * Calculator instance
- * ===================
- *
- * ```c
- * include "tblite/calculator.h"
- * ```
+/**@file tblite/calculator.h
+ * @brief
+ * Provides a single point calculator for performing extended tight-binding computations.
  *
  * Provides a parametrized type #tblite_calculator storing the method parameters required
  * for the evaluation of single point calculations. The calculator is parametrized for

--- a/include/tblite/container.h
+++ b/include/tblite/container.h
@@ -15,13 +15,9 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/container.h
- * Interaction container
- * =====================
- *
- * ```c
- * include "tblite/container.h"
- * ```
+/**@file tblite/container.h
+ * @brief
+ * Provides an interaction container which can be added to an #tblite_calculator.
  */
 
 #pragma once

--- a/include/tblite/container.h
+++ b/include/tblite/container.h
@@ -17,7 +17,7 @@
 
 /**@file tblite/container.h
  * @brief
- * Provides an interaction container which can be added to an #tblite_calculator.
+ * Provides an interaction container which can be added to a #tblite_calculator.
  */
 
 #pragma once

--- a/include/tblite/context.h
+++ b/include/tblite/context.h
@@ -15,13 +15,10 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/context.h
- * Context handler
- * ===============
- *
- * ```c
- * include "tblite/context.h"
- * ```
+/**@file tblite/context.h
+ * @brief
+ * Provides a persistent configuration object to modify the behaviour of a calculation.
+ * Acts as an error handler.
  *
  * The environment context #tblite_context can be considered a persistent setup for all
  * calculations performed with the library, it is usually used together with calculator

--- a/include/tblite/error.h
+++ b/include/tblite/error.h
@@ -15,13 +15,9 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/error.h
- * Error handler
- * =============
- *
- * ```c
- * include "tblite/error.h"
- * ```
+/**@file tblite/error.h
+ * @brief
+ * Provides a light-weight error handler for communicating with the library.
  *
  * The library provides two different kinds handlers, a light error handle type
  * #tblite_error is defined here.

--- a/include/tblite/macros.h
+++ b/include/tblite/macros.h
@@ -15,14 +15,8 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/macros.h
- * Macro definitions
- * =================
- *
- * ```c
- * include "tblite/macros.h"
- * ```
- *
+/**@file tblite/macros.h
+ * @brief
  * General macro definitions for the tblite C API bindings.
  */
 

--- a/include/tblite/param.h
+++ b/include/tblite/param.h
@@ -15,18 +15,13 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/param.h
- * Parametrization records
- * =======================
- *
- * ```c
- * include "tblite/param.h"
- * ```
- *
+/**@file tblite/param.h
+ * @brief
  * Provides a representation of a parametrization of an xTB Hamiltonian which can be used
- * to instantiate a #tblite_calculator object. The parametrization itself can be represented
- * as a #tblite_table data structure, which provides the possibility to customize the
- * parametrization programmatically.
+ * to instantiate a #tblite_calculator object.
+ *
+ * The parametrization data itself can be represented as a #tblite_table data structure,
+ * which provides the possibility to customize the parametrization programmatically.
  */
 
 #pragma once

--- a/include/tblite/result.h
+++ b/include/tblite/result.h
@@ -15,14 +15,8 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/result.h
- * Result container
- * ================
- *
- * ```c
- * include "tblite/result.h"
- * ```
- *
+/**@file tblite/result.h
+ * @brief
  * Provides a storage container #tblite_result for all persistent quantities produced
  * in a calculation by #tblite_get_singlepoint. The data stored in #tblite_result can
  * be used as restart data for subsequent calculations.

--- a/include/tblite/structure.h
+++ b/include/tblite/structure.h
@@ -15,16 +15,12 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/structure.h
- * Molecular structure data
- * ========================
- *
- * ```c
- * include "tblite/structure.h"
- * ```
- *
+/**@file tblite/structure.h
+ * @brief
  * The structure data #tblite_structure is used to represent the system of interest
- * in the library. It contains immutable system specific information like the
+ * in the library.
+ *
+ * It contains immutable system specific information like the
  * number of atoms, the unique atom groups and the boundary conditions as well as
  * mutable geometry data like cartesian coordinates and lattice parameters.
  *

--- a/include/tblite/table.h
+++ b/include/tblite/table.h
@@ -15,17 +15,12 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/table.h
- * Table data structure
- * ====================
+/**@file tblite/table.h
+ * @brief
+ * Provides a representation of a generic table data structure.
  *
- * ```c
- * include "tblite/table.h"
- * ```
- *
- * Representation of a generic table data structure #tblite_table. Used to mirror the
- * data available in the #tblite_param object. It aims to provide a programmatic accessible
- * representation of the parametrization records.
+ * Used to mirror the data available in the #tblite_param object. It aims to provide a
+ * programmatic accessible representation of the parametrization records.
  */
 
 #pragma once

--- a/include/tblite/version.h
+++ b/include/tblite/version.h
@@ -15,14 +15,8 @@
  * along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** @file tblite/version.h
- * Version query
- * =============
- *
- * ```c
- * include "tblite/version.h"
- * ```
- *
+/**@file tblite/version.h
+ * @brief
  * Provides access to the version, compatibility and features exported by this API.
  */
 

--- a/src/tblite/CMakeLists.txt
+++ b/src/tblite/CMakeLists.txt
@@ -45,6 +45,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 list(
   APPEND srcs
   "${dir}/adjlist.f90"
+  "${dir}/basis.f90"
   "${dir}/blas.f90"
   "${dir}/container.f90"
   "${dir}/context.f90"

--- a/src/tblite/CMakeLists.txt
+++ b/src/tblite/CMakeLists.txt
@@ -48,7 +48,9 @@ list(
   "${dir}/blas.f90"
   "${dir}/container.f90"
   "${dir}/context.f90"
+  "${dir}/coulomb.f90"
   "${dir}/cutoff.f90"
+  "${dir}/data.f90"
   "${dir}/disp.f90"
   "${dir}/lapack.f90"
   "${dir}/ncoord.f90"
@@ -64,6 +66,7 @@ list(
   "${dir}/version.f90"
   "${dir}/wavefunction.f90"
   "${dir}/wignerseitz.f90"
+  "${dir}/xtb.f90"
 )
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/tblite/adjlist.f90
+++ b/src/tblite/adjlist.f90
@@ -14,27 +14,32 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/adjlist.f90
+!> Sparse neighbour map / adjacency list implementation.
+
 !> Implementation of a sparse neighbour map in compressed sparse row format.
 !>
 !> A symmetric neighbour map given in dense format like
 !>
-!>       | 1 | 2 | 3 | 4 | 5 | 6
-!>    ---|---|---|---|---|---|---
-!>     1 |   | x |   | x | x |
-!>     2 | x |   | x |   | x | x
-!>     3 |   | x |   | x |   | x
-!>     4 | x |   | x |   | x | x
-!>     5 | x | x |   | x |   |
-!>     6 |   | x | x | x |   |
+!>   |   | 1 | 2 | 3 | 4 | 5 | 6 |
+!>   |---|---|---|---|---|---|---|
+!>   | 1 |   | x |   | x | x |   |
+!>   | 2 | x |   | x |   | x | x |
+!>   | 3 |   | x |   | x |   | x |
+!>   | 4 | x |   | x |   | x | x |
+!>   | 5 | x | x |   | x |   |   |
+!>   | 6 |   | x | x | x |   |   |
 !>
 !> Is stored in two compressed array identifying the neighbouring atom `nlat`
 !> and its cell index `nltr`. Two index arrays `inl` for the offset
 !> and `nnl` for the number of entries map the atomic index to the row index.
 !>
-!>    inl   =  0,       3,          7,      10,         14,      17, 20
-!>    nnl   =  |  2 ->  |  3 ->     |  2 ->  |  3 ->     |  2 ->  |  |
-!>    nlat  =     2, 4, 5, 1, 3, 5, 6, 2, 4, 6, 1, 3, 5, 6, 1, 2, 4, 2, 3, 4
-!>    nltr  =     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+!> ```
+!> inl   =  0,       3,          7,      10,         14,      17, 20
+!> nnl   =  |  2 ->  |  3 ->     |  2 ->  |  3 ->     |  2 ->  |  |
+!> nlat  =     2, 4, 5, 1, 3, 5, 6, 2, 4, 6, 1, 3, 5, 6, 1, 2, 4, 2, 3, 4
+!> nltr  =     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+!> ```
 !>
 !> An alternative representation would be to store just the offsets in `inl` and
 !> additional beyond the last element the total number of neighbors. However,
@@ -49,6 +54,7 @@ module tblite_adjlist
 
    public :: adjacency_list, new_adjacency_list
 
+   !> @class adjacency_list
    !> Neighbourlist in CSR format
    type :: adjacency_list
       !> Offset index in the neighbour map

--- a/src/tblite/api/calculator.f90
+++ b/src/tblite/api/calculator.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/calculator.f90
+!> Provides API exports for the #tblite_calculator handle.
+
 !> API export for managing tight-binding parameters and calculators
 module tblite_api_calculator
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/container.f90
+++ b/src/tblite/api/container.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/container.f90
+!> Provides API exports for the #tblite_container handle.
+
 !> API export for managing interaction containers
 module tblite_api_container
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/context.f90
+++ b/src/tblite/api/context.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/context.f90
+!> Provides API exports for the #tblite_context handle.
+
 !> API export for environment context setup
 module tblite_api_context
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/error.f90
+++ b/src/tblite/api/error.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/error.f90
+!> Provides API exports for the #tblite_error handle.
+
 !> API export for error handling
 module tblite_api_error
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/param.f90
+++ b/src/tblite/api/param.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/param.f90
+!> Provides API exports for the #tblite_param handle.
+
+!> API export for managing parametrization records.
 module tblite_api_param
    use, intrinsic :: iso_c_binding
    use mctc_env, only : fatal_error

--- a/src/tblite/api/result.f90
+++ b/src/tblite/api/result.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/api/result.f90
+!> Provides API exports for the #tblite_result handle.
+
+!> API export for managing calculation results
 module tblite_api_result
    use, intrinsic :: iso_c_binding
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/api/result.f90
+++ b/src/tblite/api/result.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/result.f90
 module tblite_api_result
    use, intrinsic :: iso_c_binding
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/api/structure.f90
+++ b/src/tblite/api/structure.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/structure.f90
+!> Provides API exports for the #tblite_structure handle.
+
 !> API export for working with molecular structure data objects
 module tblite_api_structure
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/table.f90
+++ b/src/tblite/api/table.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/table.f90
+!> Provides API exports for the #tblite_table handle.
+
+!> API export for managing data tables
 module tblite_api_table
    use, intrinsic :: iso_c_binding
    use mctc_env, only : fatal_error

--- a/src/tblite/api/utils.f90
+++ b/src/tblite/api/utils.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/utils.f90
+!> Common utilities for all API exports
+
+!> Provides utilities used for all API export modules
 module tblite_api_utils
    use, intrinsic :: iso_c_binding
    implicit none

--- a/src/tblite/api/version.f90
+++ b/src/tblite/api/version.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/api/version.f90
+!> Provides a stable version query with #tblite_get_version.
+
 !> API export for the version information of the library
 module tblite_api_version
    use, intrinsic :: iso_c_binding

--- a/src/tblite/api/version.f90
+++ b/src/tblite/api/version.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/api
+!> Provides C API bindings for tblite library
+
 !> @file tblite/api/version.f90
 !> Provides a stable version query with #tblite_get_version.
 

--- a/src/tblite/basis.f90
+++ b/src/tblite/basis.f90
@@ -14,21 +14,21 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> @dir tblite/wavefunction
-!> Contains wavefunction related information
+!> @dir tblite/basis
+!> Contains basis set related implementations
 
-!> @file tblite/wavefunction.f90
-!> Provides reexports of wavefunction related procedures and types
+!> @file tblite/basis.f90
+!> Reexports the basis set related data classes
 
-!> Proxy module for wavefunction related types and procedures
-module tblite_wavefunction
-   use tblite_wavefunction_guess, only : sad_guess, eeq_guess
-   use tblite_wavefunction_mulliken, only : get_molecular_dipole_moment, &
-      & get_molecular_quadrupole_moment
-   use tblite_wavefunction_spin, only : magnet_to_updown, updown_to_magnet
-   use tblite_wavefunction_type, only : wavefunction_type, new_wavefunction, &
-      & get_density_matrix, get_alpha_beta_occupation
+!> Proxy module for the basis set related procedures and types
+module tblite_basis
+   use tblite_basis_ortho, only : orthogonalize
+   use tblite_basis_slater, only : slater_to_gauss
+   use tblite_basis_type, only : basis_type, new_basis, get_cutoff, cgto_type
    implicit none
-   public
+   private
 
-end module tblite_wavefunction
+   public :: basis_type, new_basis, get_cutoff, cgto_type
+   public :: orthogonalize
+   public :: slater_to_gauss
+end module tblite_basis

--- a/src/tblite/basis/ortho.f90
+++ b/src/tblite/basis/ortho.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/basis/ortho.f90
+!> Provides utilities for orthonormalizing basis functions
+
 !> Gram-Schmidt orthonormalization routines for contracted Gaussian basis functions
 module tblite_basis_ortho
    use mctc_env, only : wp

--- a/src/tblite/basis/slater.f90
+++ b/src/tblite/basis/slater.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/basis/slater.f90
+!> Provides coefficients for contracted Gaussian type orbitals to approximate Slater
+!> type orbitals.
+
 !> Implements expansion of Slater functions to contracted Gaussian functions.
 !>
 !> All the coefficients are taken from:

--- a/src/tblite/basis/type.f90
+++ b/src/tblite/basis/type.f90
@@ -24,8 +24,7 @@ module tblite_basis_type
    implicit none
    private
 
-   public :: cgto_type
-   public :: basis_type, new_basis, get_cutoff
+   public :: new_basis, get_cutoff
 
    !> Maximum contraction length of basis functions.
    !> The limit is chosen as twice the maximum size returned by the STO-NG expansion

--- a/src/tblite/basis/type.f90
+++ b/src/tblite/basis/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/basis/type.f90
+!> Provides data types for managing basis set information
+
 !> Gaussian type basis set data
 module tblite_basis_type
    use mctc_env, only : wp
@@ -29,7 +32,7 @@ module tblite_basis_type
    integer, parameter :: maxg = 12
 
    !> Contracted Gaussian type basis function
-   type :: cgto_type
+   type, public :: cgto_type
       !> Angular momentum of this basis function
       integer :: ang = -1
       !> Contraction length of this basis function
@@ -42,7 +45,7 @@ module tblite_basis_type
    end type cgto_type
 
    !> Collection of information regarding the basis set of a system
-   type :: basis_type
+   type, public :: basis_type
       !> Maximum angular momentum of all basis functions,
       !> used to determine scratch size in integral calculation
       integer :: maxl = 0

--- a/src/tblite/blas.f90
+++ b/src/tblite/blas.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/blas
+!> Contains wrappers for the basic linear algebra subprograms
+
+!> @file tblite/blas.f90
+!> Provides high-level interfaces to the basic linear algebra subprograms
+
 !> Proxy module to reexport high-level basic linear algebra subprogram wrappers
 module tblite_blas
    use tblite_blas_level1, only : dot => wrap_dot

--- a/src/tblite/blas/level1.f90
+++ b/src/tblite/blas/level1.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/blas/level1.f90
+!> Provides interfactes to level 1 BLAS routines
+
 !> High-level interface to level 1 basic linear algebra subprogram operations
 module tblite_blas_level1
    use mctc_env, only : sp, dp

--- a/src/tblite/blas/level2.f90
+++ b/src/tblite/blas/level2.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the Lesser GNU General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/blas/level2.f90
+!> Provides interfactes to level 2 BLAS routines
+
 !> High-level interface to level 2 basic linear algebra subprogram operations
 module tblite_blas_level2
    use mctc_env, only : sp, dp

--- a/src/tblite/blas/level3.f90
+++ b/src/tblite/blas/level3.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/blas/level3.f90
+!> Provides interfactes to level 3 BLAS routines
+
 !> High-level interface to level 3 basic linear algebra subprogram operations
 module tblite_blas_level3
    use mctc_env, only : sp, dp

--- a/src/tblite/classical/halogen.f90
+++ b/src/tblite/classical/halogen.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/classical
+!> Contains classical correction potentials
+
 !> @file tblite/classical/halogen.f90
 !> Provides a classical halogen bonding correction
 
@@ -28,7 +31,7 @@ module tblite_classical_halogen
    implicit none
    private
 
-   public :: halogen_correction, new_halogen_correction
+   public :: new_halogen_correction
 
 
    !> Container for evaluating halogen bonding energy terms by a classical potential

--- a/src/tblite/classical/halogen.f90
+++ b/src/tblite/classical/halogen.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/classical/halogen.f90
+!> Provides a classical halogen bonding correction
+
 !> Classical correction term for halogen bonding contributions
 module tblite_classical_halogen
    use mctc_env, only : wp
@@ -23,12 +26,13 @@ module tblite_classical_halogen
    use tblite_data_atomicrad, only : get_atomic_rad
    use tblite_repulsion_type, only : repulsion_type
    implicit none
+   private
 
    public :: halogen_correction, new_halogen_correction
 
 
    !> Container for evaluating halogen bonding energy terms by a classical potential
-   type, extends(repulsion_type) :: halogen_correction
+   type, public, extends(repulsion_type) :: halogen_correction
       !> Interaction strength of the halogen bond
       real(wp), allocatable :: bond_strength(:)
       !> Atomic radii of all atoms

--- a/src/tblite/container.f90
+++ b/src/tblite/container.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/container
 !> Proxy module for general interaction containers.
 !>
 !> Provides access to the abstract base class [[container_type]] for declaring

--- a/src/tblite/container/cache.f90
+++ b/src/tblite/container/cache.f90
@@ -22,7 +22,7 @@ module tblite_container_cache
    implicit none
    private
 
-   public :: container_cache, resize
+   public :: resize
 
    !> Restart data for an interaction container
    type, public :: container_cache

--- a/src/tblite/container/cache.f90
+++ b/src/tblite/container/cache.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/container/cache.f90
+!> Provides a cache for use with interaction containers
+
 !> Definition of restart data cache
 module tblite_container_cache
    implicit none
@@ -22,7 +25,7 @@ module tblite_container_cache
    public :: container_cache, resize
 
    !> Restart data for an interaction container
-   type :: container_cache
+   type, public :: container_cache
       !> Label identifying this contribution
       character(len=:), allocatable :: label
       !> Actual restart data

--- a/src/tblite/container/list.f90
+++ b/src/tblite/container/list.f90
@@ -30,8 +30,6 @@ module tblite_container_list
    implicit none
    private
 
-   public :: container_list
-
 
    !> Wrapped container type for creation of lists
    type :: container_node

--- a/src/tblite/container/list.f90
+++ b/src/tblite/container/list.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/container/list.f90
+!> Provides a collection for several interaction containers
+
 !> Definition of list of general interaction contaienrs
 module tblite_container_list
    use mctc_env, only : wp
@@ -37,7 +40,7 @@ module tblite_container_list
    end type container_node
 
    !> List of interaction containers
-   type, extends(container_type) :: container_list
+   type, public, extends(container_type) :: container_list
       private
       !> Number of stored containers
       integer :: nc = 0

--- a/src/tblite/container/type.f90
+++ b/src/tblite/container/type.f90
@@ -28,8 +28,6 @@ module tblite_container_type
    implicit none
    private
 
-   public :: container_type
-
    !> Abstract base class for interactions containers
    type, public, abstract :: container_type
       !> Label identifying this contribution

--- a/src/tblite/container/type.f90
+++ b/src/tblite/container/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/container/type.f90
+!> Provides an abstract base class for interaction containers
+
 !> Definition of abstract base class for general interactions
 module tblite_container_type
    use mctc_env, only : wp
@@ -28,7 +31,7 @@ module tblite_container_type
    public :: container_type
 
    !> Abstract base class for interactions containers
-   type, abstract :: container_type
+   type, public, abstract :: container_type
       !> Label identifying this contribution
       character(len=:), allocatable :: label
    contains

--- a/src/tblite/context.f90
+++ b/src/tblite/context.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/context
+!> Contains the individual components of the context manager.
+
+!> @file tblite/context.f90
+!> Provides reexports for the context manager.
+
 !> Proxy module for the calculation context related data types.
 !>
 !> Provides access to the [[context_type]] to manage the calculation.

--- a/src/tblite/context.f90
+++ b/src/tblite/context.f90
@@ -22,35 +22,37 @@
 
 !> Proxy module for the calculation context related data types.
 !>
-!> Provides access to the [[context_type]] to manage the calculation.
+!> Provides access to the #tblite_context_type::context_type to manage the calculation.
 !> The context stores error messages generated while running which can be
-!> queried using the [[context_type:failed]] procedure. To access the actual
-!> errors the messages can be removed using the [[context:get_error]] procedure.
+!> queried using the #tblite_context_type::context_type::failed procedure.
+!> To access the actual errors the messages can be removed using the
+!> #tblite_context_type::context_type::get_error procedure.
 !>
-!> Errors can be pushed to a context by using the [[context_type:set_error]] procedure,
+!> Errors can be pushed to a context by using #tblite_context_type::context_type::set_error,
 !> A context containing any error will automatically be marked as failed. Once all
-!> error messages are removed from the context with [[context_type:get_error]] the
-!> failed status is removed from the context again.
+!> error messages are removed from again with #tblite_context_type::context_type::get_error
+!> the failed status is removed from the context as well.
 !>
-!> The context provides also access to output by providing the [[context_type:message]]
-!> procedure. Using this procedure for printouts ensures they are correctly handled in
-!> case of API usage.
+!> The context provides also access to output by providing the
+!> #tblite_context_type::context_type::message procedure. Using this procedure
+!> for printouts ensures they are correctly handled in case of API usage.
 !>
 !> An output verbosity is available in the context as the member verbosity, all procedures
 !> with access to the context will default to the verbosity of the context unless
 !> the verbosity level is overwritten by an argument.
 !>
-!> To cutomize the output the [[context_logger]] abstract base class is available.
-!> It provides a [[context_logger:message]] procedure which is used by the context
-!> to create output. This type can be used to create callbacks for customizing or
-!> redirecting the output of the library, e.g. when used from C or Python.
+!> To cutomize the output the #tblite_context_logger::context_logger abstract base class
+!> is available. It provides a #tblite_context_logger::context_logger::message procedure
+!> which is used by the context to create output. This type can be used to create callbacks
+!> for customizing or redirecting the output of the library, e.g. when used from C or Python.
 !>
-!> ANSI escape sequences are available via the [[context_terminal]] class and which is
-!> instantiated in the [[context_type:terminal]] member. The terminal instance provides
-!> access to various terminal formatting codes to produce the respective ANSI escape
-!> sequences if the terminal is created with color support, otherwise return empty strings.
-!> Detecting whether the terminal supports ANSI escape sequences is left as excerise to
-!> the consumer of the [[context_terminal]] class.
+!> ANSI escape sequences are available via the #tblite_context_terminal::context_terminal
+!> class and which is instantiated in the #tblite_context_type::context_type::terminal
+!> member. The terminal instance provides access to various terminal formatting codes to
+!> produce the respective ANSI escape sequences if the terminal is created with color
+!> support, otherwise return empty strings. Detecting whether the terminal supports
+!> ANSI escape sequences is left as excerise to the consumer of the
+!> #tblite_context_terminal::context_terminal class.
 !>
 !> For convenience operators are provided to add escape codes as well as concatenate
 !> them directly with strings.

--- a/src/tblite/context/logger.f90
+++ b/src/tblite/context/logger.f90
@@ -22,11 +22,9 @@ module tblite_context_logger
    implicit none
    private
 
-   public :: context_logger
-
 
    !> Base class defining the logger interface
-   type, abstract :: context_logger
+   type, public, abstract :: context_logger
    contains
       !> Entry point for displaying a string in the logger
       procedure(message), deferred :: message

--- a/src/tblite/context/logger.f90
+++ b/src/tblite/context/logger.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/context/logger.f90
+!> Provides an abstract base class for implementing a logger
+
 !> Logger to display strings
 module tblite_context_logger
    implicit none

--- a/src/tblite/context/terminal.f90
+++ b/src/tblite/context/terminal.f90
@@ -23,7 +23,7 @@ module tblite_context_terminal
    implicit none
    private
 
-   public :: context_terminal, escape, operator(+), operator(//)
+   public :: escape, operator(+), operator(//)
 
    !> Container for terminal escape code
    type :: color
@@ -76,7 +76,7 @@ module tblite_context_terminal
 
 
    !> Colorizer class for handling colorful output in the terminal
-   type :: context_terminal
+   type, public :: context_terminal
 
       type(color) :: &
          reset = color(), &

--- a/src/tblite/context/terminal.f90
+++ b/src/tblite/context/terminal.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/context/terminal.f90
+!> Provides a terminal class to safely use ANSI escape sequences
+
 !> Support for ANSI escape sequences to get colorful terminal output
 module tblite_context_terminal
    use mctc_env, only : i1

--- a/src/tblite/context/type.f90
+++ b/src/tblite/context/type.f90
@@ -26,11 +26,9 @@ module tblite_context_type
    implicit none
    private
 
-   public :: context_type
-
 
    !> Calculation context type for error handling and output messages
-   type :: context_type
+   type, public :: context_type
       !> Default output unit for this context
       integer :: unit = output_unit
       !> Default verbosity for procedures using this context

--- a/src/tblite/context/type.f90
+++ b/src/tblite/context/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/context/type.f90
+!> Provides a context manager for storing persistent environment settings
+
 !> Calculation context for storing and communicating with the environment
 module tblite_context_type
    use iso_fortran_env, only : output_unit

--- a/src/tblite/coulomb.f90
+++ b/src/tblite/coulomb.f90
@@ -1,0 +1,43 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> @dir tblite/coulomb
+!> Contains the Coulomb related interactions.
+
+!> @file tblite/coulomb.f90
+!> Reexports of the Coulombic interaction containers.
+
+!> Proxy module for handling Coulomb-type interactions
+module tblite_coulomb
+   use tblite_coulomb_cache, only : coulomb_cache
+   use tblite_coulomb_charge, only : coulomb_charge_type, coulomb_kernel, &
+      & effective_coulomb, new_effective_coulomb, &
+      & average_interface, harmonic_average, arithmetic_average, geometric_average, &
+      & gamma_coulomb, new_gamma_coulomb
+   use tblite_coulomb_multipole, only : damped_multipole, new_damped_multipole
+   use tblite_coulomb_thirdorder, only : onsite_thirdorder, new_onsite_thirdorder
+   use tblite_coulomb_type, only : coulomb_type
+   implicit none
+
+   public :: coulomb_type
+   public :: coulomb_cache
+   public :: coulomb_charge_type, coulomb_kernel
+   public :: effective_coulomb, new_effective_coulomb
+   public :: average_interface, harmonic_average, arithmetic_average, geometric_average
+   public :: gamma_coulomb, new_gamma_coulomb
+   public :: damped_multipole, new_damped_multipole
+   public :: onsite_thirdorder, new_onsite_thirdorder
+end module tblite_coulomb

--- a/src/tblite/coulomb/cache.f90
+++ b/src/tblite/coulomb/cache.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/cache.f90
+!> Provides a cache specific for all Coulomb interactions
+
 !> Data container for mutable data in electrostatic calculations
 module tblite_coulomb_cache
    use mctc_env, only : wp

--- a/src/tblite/coulomb/charge.f90
+++ b/src/tblite/coulomb/charge.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/coulomb/charge
+!> Contains the implementation of the isotropic second-order electrostatics
+
+!> @file tblite/coulomb/charge.f90
+!> Provides a reexport of the isotropic second-order electrostatic implementations
+
 !> Proxy module for defining isotropic electrostatic interactions
 module tblite_coulomb_charge
    use tblite_coulomb_charge_effective, only : effective_coulomb, new_effective_coulomb, &

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -34,12 +34,12 @@ module tblite_coulomb_charge_effective
    implicit none
    private
 
-   public :: effective_coulomb, new_effective_coulomb
+   public :: new_effective_coulomb
    public :: average_interface, harmonic_average, arithmetic_average, geometric_average
 
 
    !> Effective, Klopman-Ohno-type, second-order electrostatics
-   type, extends(coulomb_charge_type) :: effective_coulomb
+   type, public, extends(coulomb_charge_type) :: effective_coulomb
       !> Hubbard parameter for each shell and species
       real(wp), allocatable :: hubbard(:, :, :, :)
       !> Exponent of Coulomb kernel

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/charge/effective.f90
+!> Provides an effective Coulomb operator for isotropic electrostatic interactions
+
 !> Isotropic second-order electrostatics using an effective Coulomb operator
 module tblite_coulomb_charge_effective
    use mctc_env, only : wp

--- a/src/tblite/coulomb/charge/gamma.f90
+++ b/src/tblite/coulomb/charge/gamma.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/charge/gamma.f90
+!> Provides the DFTB Coulomb functional for isotropic electrostatic interactions.
+
 !> Isotropic second-order electrostatics using the DFTB Coulomb functional.
 module tblite_coulomb_charge_gamma
    use mctc_env, only : wp

--- a/src/tblite/coulomb/charge/gamma.f90
+++ b/src/tblite/coulomb/charge/gamma.f90
@@ -34,11 +34,11 @@ module tblite_coulomb_charge_gamma
    implicit none
    private
 
-   public :: gamma_coulomb, new_gamma_coulomb
+   public :: new_gamma_coulomb
 
 
    !> DFTB Gamma functional second-order electrostatics
-   type, extends(coulomb_charge_type) :: gamma_coulomb
+   type, public, extends(coulomb_charge_type) :: gamma_coulomb
       !> Chemical hardness for each shell and species
       real(wp), allocatable :: hubbard(:, :)
       !> Long-range cutoff

--- a/src/tblite/coulomb/charge/type.f90
+++ b/src/tblite/coulomb/charge/type.f90
@@ -30,11 +30,9 @@ module tblite_coulomb_charge_type
    implicit none
    private
 
-   public :: coulomb_charge_type
-
 
    !> General second-order electrostatics
-   type, extends(coulomb_type), abstract :: coulomb_charge_type
+   type, public, extends(coulomb_type), abstract :: coulomb_charge_type
       !> Number of shells for each atom
       integer, allocatable :: nshell(:)
       !> Index offset for each shell

--- a/src/tblite/coulomb/charge/type.f90
+++ b/src/tblite/coulomb/charge/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/charge/type.f90
+!> Provides a general base class for electrostatic interactions
+
 !> General isotropic second-order electrostatics model
 module tblite_coulomb_charge_type
    use mctc_env, only : wp

--- a/src/tblite/coulomb/ewald.f90
+++ b/src/tblite/coulomb/ewald.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/ewald.f90
+!> Provides an utilities for implementing Ewald summations
+
 !> Helper tools for dealing with Ewald summation related calculations
 module tblite_coulomb_ewald
    use mctc_env, only : wp

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -36,11 +36,11 @@ module tblite_coulomb_multipole
    implicit none
    private
 
-   public :: damped_multipole, new_damped_multipole
+   public :: new_damped_multipole
 
 
    !> Container to handle multipole electrostatics
-   type, extends(coulomb_type) :: damped_multipole
+   type, public, extends(coulomb_type) :: damped_multipole
       !> Damping function for inverse quadratic contributions
       real(wp) :: kdmp3 = 0.0_wp
       !> Damping function for inverse cubic contributions

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/multipole.f90
+!> Provides an implemenation of a multipole based second-order electrostatic
+
 !> Anisotropic second-order electrostatics using a damped multipole expansion
 module tblite_coulomb_multipole
    use mctc_env, only : wp

--- a/src/tblite/coulomb/thirdorder.f90
+++ b/src/tblite/coulomb/thirdorder.f90
@@ -30,10 +30,10 @@ module tblite_coulomb_thirdorder
    implicit none
    private
 
-   public :: onsite_thirdorder, new_onsite_thirdorder
+   public :: new_onsite_thirdorder
 
    !> Onsite correction for third-order charge expansion
-   type, extends(coulomb_type) :: onsite_thirdorder
+   type, public, extends(coulomb_type) :: onsite_thirdorder
       !> Whether the third order contribution is shell-dependent
       logical :: shell_resolved
       !> Number of shell for each atom

--- a/src/tblite/coulomb/thirdorder.f90
+++ b/src/tblite/coulomb/thirdorder.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/thirdorder.f90
+!> Provides an onsite third-order electrostatic interaction
+
 !> Isotropic third-order onsite correction
 module tblite_coulomb_thirdorder
    use mctc_env, only : wp

--- a/src/tblite/coulomb/type.f90
+++ b/src/tblite/coulomb/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/coulomb/type.f90
+!> Provides a base class for all Coulombic interactions
+
 !> Definition of the abstract base class for electrostatic and coulombic interactions
 module tblite_coulomb_type
    use mctc_env, only : wp

--- a/src/tblite/coulomb/type.f90
+++ b/src/tblite/coulomb/type.f90
@@ -19,20 +19,12 @@
 
 !> Definition of the abstract base class for electrostatic and coulombic interactions
 module tblite_coulomb_type
-   use mctc_env, only : wp
-   use mctc_io, only : structure_type
-   use tblite_container_cache, only : container_cache
    use tblite_container_type, only : container_type
-   use tblite_scf_info, only : scf_info
-   use tblite_scf_potential, only : potential_type
-   use tblite_wavefunction_type, only : wavefunction_type
    implicit none
    private
 
-   public :: coulomb_type
-
    !> General base class for Coulombic interactions
-   type, extends(container_type), abstract :: coulomb_type
+   type, public, extends(container_type), abstract :: coulomb_type
    end type coulomb_type
 
 end module tblite_coulomb_type

--- a/src/tblite/cutoff.f90
+++ b/src/tblite/cutoff.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/cutoff.f90
+!> Provides realspace cutoff and lattice generation
+
 !> Realspace cutoff and lattice point generator utilities
 module tblite_cutoff
    use mctc_env, only : wp

--- a/src/tblite/data.f90
+++ b/src/tblite/data.f90
@@ -14,22 +14,19 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> @file tblite/solvation/input.f90
-module tblite_solvation_input
-   use tblite_solvation_alpb, only : alpb_input
-   use tblite_solvation_cpcm, only : cpcm_input
+!> @dir tblite/data
+!> Contains element data used for defining interactions.
+
+!> @file tblite/data.f90
+!> Reexports access to element-specific data.
+
+!> Proxy module for providing access to element data.
+module tblite_data
+   use tblite_data_atomicrad, only : get_atomic_rad
+   use tblite_data_covrad, only : get_covalent_rad
+   use tblite_data_paulingen, only : get_pauling_en
+   use tblite_data_spin, only : get_spin_constant
    implicit none
-   private
 
-   public :: solvation_input
-
-
-   !> Collection of possible solvation models
-   type :: solvation_input
-      !> Input for CPCM solvation model
-      type(cpcm_input), allocatable :: cpcm
-      !> Input for ALPB solvation model
-      type(alpb_input), allocatable :: alpb
-   end type solvation_input
-
-end module tblite_solvation_input
+   public :: get_atomic_rad, get_covalent_rad, get_pauling_en, get_spin_constant
+end module tblite_data

--- a/src/tblite/data/atomicrad.f90
+++ b/src/tblite/data/atomicrad.f90
@@ -14,7 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> Atomic Radii of the Elements
+!> @file tblite/data/atomicrad.f90
+!> Provides atomic radii for all elements
+
+!> Atomic radii of the elements
 !>
 !> M. Mantina, R. Valero, C. J. Cramer, and D. G. Truhlar,
 !> in CRC Handbook of Chemistry and Physics, 91st Edition (2010-2011),

--- a/src/tblite/data/covrad.f90
+++ b/src/tblite/data/covrad.f90
@@ -14,6 +14,11 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/data/covrad.f90
+!> Provides covalent radii for all elements
+
+!> Covalent radii (taken from Pyykko and Atsumi, Chem. Eur. J. 15, 2009,
+!> 188-197), values for metals decreased by 10 %
 module tblite_data_covrad
    use mctc_env, only : wp
    use mctc_io_convert, only : aatoau

--- a/src/tblite/data/paulingen.f90
+++ b/src/tblite/data/paulingen.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/data/paulingen.f90
+!> Provides electronegativities for all elements
+
 !> Pauling electronegativities
 module tblite_data_paulingen
    use mctc_env, only : wp

--- a/src/tblite/data/spin.f90
+++ b/src/tblite/data/spin.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/data/spin.f90
+!> Provides spin constants for all elements
+
 !> Spin constants
 module tblite_data_spin
    use mctc_env, only : wp

--- a/src/tblite/disp.f90
+++ b/src/tblite/disp.f90
@@ -14,7 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> Proxy module for dispersion interactions
+!> @dir tblite/disp
+!> Contains implemenations for the evaluation of London-dispersion interactions.
+
+!> @file tblite/disp.f90
+!> Reexports of the available dispersion interactions.
+
+!> Proxy module for dispersion interactions.
 module tblite_disp
    use mctc_env, only : wp
    use tblite_disp_cache, only : dispersion_cache

--- a/src/tblite/disp/cache.f90
+++ b/src/tblite/disp/cache.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/disp/cache.f90
+!> Provides a cache for dispersion interactions
+
 !> Reusable data container for dispersion related calculations
 module tblite_disp_cache
    use mctc_env, only : wp

--- a/src/tblite/disp/d3.f90
+++ b/src/tblite/disp/d3.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/disp/d3.f90
+!> Provides a proxy for the [DFT-D3 dispersion correction](https://dftd3.readthedocs.io)
+
 !> Semiclassical DFT-D3 dispersion correction
 module tblite_disp_d3
    use mctc_env, only : wp

--- a/src/tblite/disp/d3.f90
+++ b/src/tblite/disp/d3.f90
@@ -30,11 +30,11 @@ module tblite_disp_d3
    implicit none
    private
 
-   public :: d3_dispersion, new_d3_dispersion
+   public :: new_d3_dispersion
 
 
    !> Container for DFT-D3 type dispersion correction
-   type, extends(dispersion_type) :: d3_dispersion
+   type, public, extends(dispersion_type) :: d3_dispersion
       type(d3_model) :: model
       type(rational_damping_param) :: param
       type(realspace_cutoff) :: cutoff

--- a/src/tblite/disp/d4.f90
+++ b/src/tblite/disp/d4.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/disp/d4.f90
+!> Provides a proxy for the [DFT-D4 dispersion correction](https://dftd4.readthedocs.io)
+
 !> Generally applicable charge-dependent London-dispersion correction, DFT-D4.
 module tblite_disp_d4
    use mctc_env, only : wp

--- a/src/tblite/disp/d4.f90
+++ b/src/tblite/disp/d4.f90
@@ -36,11 +36,11 @@ module tblite_disp_d4
    implicit none
    private
 
-   public :: d4_dispersion, new_d4_dispersion, get_eeq_charges
+   public :: new_d4_dispersion, get_eeq_charges
 
 
    !> Container for self-consistent D4 dispersion interactions
-   type, extends(dispersion_type) :: d4_dispersion
+   type, public, extends(dispersion_type) :: d4_dispersion
       !> Instance of the actual D4 dispersion model
       type(d4_model) :: model
       !> Rational damping parameters

--- a/src/tblite/disp/type.f90
+++ b/src/tblite/disp/type.f90
@@ -19,19 +19,12 @@
 
 !> Definition of abstract base class for dispersion interactions
 module tblite_disp_type
-   use mctc_env, only : wp
-   use mctc_io, only : structure_type
    use tblite_container_type, only : container_type
-   use tblite_scf_info, only : scf_info
-   use tblite_scf_potential, only : potential_type
-   use tblite_wavefunction_type, only : wavefunction_type
    implicit none
    private
 
-   public :: dispersion_type
-
    !> Abstract base class for dispersion interactions
-   type, extends(container_type), abstract :: dispersion_type
+   type, public, extends(container_type), abstract :: dispersion_type
    end type dispersion_type
 
 

--- a/src/tblite/disp/type.f90
+++ b/src/tblite/disp/type.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/disp/type.f90
+!> Provides a common base class for dispersion interactions
+
 !> Definition of abstract base class for dispersion interactions
 module tblite_disp_type
    use mctc_env, only : wp

--- a/src/tblite/external/field.f90
+++ b/src/tblite/external/field.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/external/field.f90
 !> Interaction of Hamiltonian with external fields
 module tblite_external_field
    use mctc_env, only : wp

--- a/src/tblite/external/field.f90
+++ b/src/tblite/external/field.f90
@@ -14,7 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/external
+!> Contains external potentials
+
 !> @file tblite/external/field.f90
+!> Provides interaction of charge density with external fields
+
 !> Interaction of Hamiltonian with external fields
 module tblite_external_field
    use mctc_env, only : wp
@@ -28,10 +33,10 @@ module tblite_external_field
    implicit none
    private
 
-   public :: electric_field, new_electric_field
+   public :: new_electric_field
 
    !> Container for contribution from an instantaneous electric field
-   type, extends(container_type) :: electric_field
+   type, public, extends(container_type) :: electric_field
       !> Instantaneous electric field
       real(wp) :: efield(3) = 0.0_wp
    contains

--- a/src/tblite/fit/newuoa.f90
+++ b/src/tblite/fit/newuoa.f90
@@ -1,5 +1,6 @@
 ! SPDX-Identifier: BSD-3-Clause
 
+!> @file tblite/fit/newuoa.f90
 !> NEWUOA: **NEW** **U**nconstrained **O**ptimization **A**lgorithm
 !>
 !> The purpose of NEWUOA is to seek the least value of a function F of several

--- a/src/tblite/fit/newuoa.f90
+++ b/src/tblite/fit/newuoa.f90
@@ -1,6 +1,8 @@
 ! SPDX-Identifier: BSD-3-Clause
 
 !> @file tblite/fit/newuoa.f90
+!> Provides the new unconstrained optimization algorithm
+
 !> NEWUOA: **NEW** **U**nconstrained **O**ptimization **A**lgorithm
 !>
 !> The purpose of NEWUOA is to seek the least value of a function F of several

--- a/src/tblite/fit/settings.f90
+++ b/src/tblite/fit/settings.f90
@@ -14,7 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/fit
+!> Contains routines for parameter optimization
+
 !> @file tblite/fit/settings.f90
+!> Provides setting for the optimization driver
+
+!> Declaration of options for the optimization driver
 module tblite_fit_settings
    use mctc_env, only : wp, error_type, fatal_error
    use tblite_param_serde, only : serde_record
@@ -23,9 +29,8 @@ module tblite_fit_settings
    implicit none
    private
 
-   public :: fit_settings
-
-   type, extends(serde_record) :: fit_settings
+   !> Optimization configuration
+   type, public, extends(serde_record) :: fit_settings
       character(len=:), allocatable :: method
       character(len=:), allocatable :: script
       character(len=:), allocatable :: output

--- a/src/tblite/fit/settings.f90
+++ b/src/tblite/fit/settings.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/fit/settings.f90
 module tblite_fit_settings
    use mctc_env, only : wp, error_type, fatal_error
    use tblite_param_serde, only : serde_record

--- a/src/tblite/integral/dipole.f90
+++ b/src/tblite/integral/dipole.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/integral/dipole.f90
+!> Provides evaluation of dipole moment integrals
+
 !> Implementation of dipole moment integrals
 module tblite_integral_dipole
    use mctc_env, only : wp

--- a/src/tblite/integral/dipole.f90
+++ b/src/tblite/integral/dipole.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/integral/dipole.f90
 !> Implementation of dipole moment integrals
 module tblite_integral_dipole
    use mctc_env, only : wp

--- a/src/tblite/integral/multipole.f90
+++ b/src/tblite/integral/multipole.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/integral/multipole.f90
 !> Implementation of multipole moment integrals, dipole and quadrupole.
 module tblite_integral_multipole
    use mctc_env, only : wp

--- a/src/tblite/integral/multipole.f90
+++ b/src/tblite/integral/multipole.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/integral/multipole.f90
+!> Provides evaluation of multipole moment integrals
+
 !> Implementation of multipole moment integrals, dipole and quadrupole.
 module tblite_integral_multipole
    use mctc_env, only : wp

--- a/src/tblite/integral/overlap.f90
+++ b/src/tblite/integral/overlap.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/integral/overlap.f90
 !> Implementation of overlap integrals
 module tblite_integral_overlap
    use mctc_env, only : wp

--- a/src/tblite/integral/overlap.f90
+++ b/src/tblite/integral/overlap.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/integral/overlap.f90
+!> Provides evaluation of overlap integrals
+
 !> Implementation of overlap integrals
 module tblite_integral_overlap
    use mctc_env, only : wp

--- a/src/tblite/integral/trafo.f90
+++ b/src/tblite/integral/trafo.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/integral/trafo.f90
+!> Provides transformation from cartesian to spherical harmonic basis functions
+
 !> Implemenation of transformations from cartesian to spherical harmonic basis functions
 !>
 !> Spherical harmonics use standard ordering, *i.e.* [-l, ..., 0, ..., l].

--- a/src/tblite/integral/trafo.f90
+++ b/src/tblite/integral/trafo.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/integral/trafo.f90
 !> Implemenation of transformations from cartesian to spherical harmonic basis functions
 !>
 !> Spherical harmonics use standard ordering, *i.e.* [-l, ..., 0, ..., l].

--- a/src/tblite/integral/type.f90
+++ b/src/tblite/integral/type.f90
@@ -14,17 +14,22 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/integral
+!> Contains the integral evaluation implementations
+
 !> @file tblite/integral/type.f90
+!> Provides an integral storage container
+
 !> Declaration of an integral storage container to collect all overlap related integrals
 module tblite_integral_type
    use mctc_env, only : wp
    implicit none
    private
 
-   public :: integral_type, new_integral
+   public :: new_integral
 
    !> Integral container to store all overlap related integrals
-   type :: integral_type
+   type, public :: integral_type
       !> Effective one-electron Hamiltonian
       real(wp), allocatable :: hamiltonian(:, :)
       !> Overlap integrals

--- a/src/tblite/integral/type.f90
+++ b/src/tblite/integral/type.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/integral/type.f90
 !> Declaration of an integral storage container to collect all overlap related integrals
 module tblite_integral_type
    use mctc_env, only : wp

--- a/src/tblite/io/tag.f90
+++ b/src/tblite/io/tag.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/io/tag.f90
 module tblite_io_tag
    use mctc_io_utils, only : getline
    use mctc_env, only : sp, dp

--- a/src/tblite/io/tag.f90
+++ b/src/tblite/io/tag.f90
@@ -14,7 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/io
+!> Contains interfaces to IO formats
+
 !> @file tblite/io/tag.f90
+!> Provides tagged input and output routines
+
+!> Implementation of tagged input and output files
 module tblite_io_tag
    use mctc_io_utils, only : getline
    use mctc_env, only : sp, dp

--- a/src/tblite/lapack.f90
+++ b/src/tblite/lapack.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/lapack
+!> Contains wrappers for linear algebra
+
+!> @file tblite/lapack.f90
+!> Reexports of the high-level linear algebra wrappers
+
 !> Proxy module to reexport high-level linear algebra package wrappers
 module tblite_lapack
    use tblite_lapack_getrf, only : getrf => wrap_getrf

--- a/src/tblite/lapack/getrf.f90
+++ b/src/tblite/lapack/getrf.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/lapack/getrf.f90
+!> Provides wrappers for LU factorization routines
+
+!> Wrapper rountines for LU factorization
 module tblite_lapack_getrf
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/getrf.f90
+++ b/src/tblite/lapack/getrf.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/lapack/getrf.f90
 module tblite_lapack_getrf
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/getri.f90
+++ b/src/tblite/lapack/getri.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/lapack/getri.f90
 module tblite_lapack_getri
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/getri.f90
+++ b/src/tblite/lapack/getri.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/lapack/getri.f90
+!> Provides wrappers for computing a matrix inverse
+
+!> Wrappers to obtain the inverse of a matrix
 module tblite_lapack_getri
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/getrs.f90
+++ b/src/tblite/lapack/getrs.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/lapack/getrs.f90
 module tblite_lapack_getrs
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/getrs.f90
+++ b/src/tblite/lapack/getrs.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/lapack/getrs.f90
+!> Provides wrappers to solve a linear equation system
+
+!> Wrappers to solve a system of linear equations
 module tblite_lapack_getrs
    use mctc_env, only : sp, dp
    implicit none

--- a/src/tblite/lapack/sygvd.f90
+++ b/src/tblite/lapack/sygvd.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/lapack/sygvd.f90
 module tblite_lapack_sygvd
    use mctc_env, only : sp, dp, error_type, fatal_error
    use tblite_output_format, only : format_string

--- a/src/tblite/lapack/sygvd.f90
+++ b/src/tblite/lapack/sygvd.f90
@@ -15,14 +15,15 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/lapack/sygvd.f90
+!> Provides an inverface to symmetric divide-and-conquer solver
+
+!> Wrapper to symmetric divide-and-conquer solver for general eigenvalue problems
 module tblite_lapack_sygvd
    use mctc_env, only : sp, dp, error_type, fatal_error
    use tblite_output_format, only : format_string
    use tblite_scf_solver, only : solver_type
    implicit none
    private
-
-   public :: sygvd_solver
 
 
    interface lapack_sygvd
@@ -65,7 +66,8 @@ module tblite_lapack_sygvd
    end interface lapack_sygvd
 
 
-   type, extends(solver_type) :: sygvd_solver
+   !> Wrapper class for solving symmetric general eigenvalue problems
+   type, public, extends(solver_type) :: sygvd_solver
       private
       integer :: n = 0
       integer, allocatable :: iwork(:)

--- a/src/tblite/mesh/lebedev.f90
+++ b/src/tblite/mesh/lebedev.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/mesh/lebedev.f90
 !> Generator for Lebedev-Laikov grids.
 !> Adapted from John Burkardt's portation of Dmitri Laikov's C implementation of
 !>

--- a/src/tblite/mesh/lebedev.f90
+++ b/src/tblite/mesh/lebedev.f90
@@ -14,7 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/mesh
+!> Contains mesh generation routines
+
 !> @file tblite/mesh/lebedev.f90
+!> Provides angular Lebedev-Laikov grids
+
 !> Generator for Lebedev-Laikov grids.
 !> Adapted from John Burkardt's portation of Dmitri Laikov's C implementation of
 !>

--- a/src/tblite/meson.build
+++ b/src/tblite/meson.build
@@ -42,6 +42,7 @@ subdir('xtb')
 
 srcs += files(
   'adjlist.f90',
+  'basis.f90',
   'blas.f90',
   'container.f90',
   'context.f90',

--- a/src/tblite/meson.build
+++ b/src/tblite/meson.build
@@ -45,7 +45,9 @@ srcs += files(
   'blas.f90',
   'container.f90',
   'context.f90',
+  'coulomb.f90',
   'cutoff.f90',
+  'data.f90',
   'disp.f90',
   'lapack.f90',
   'ncoord.f90',
@@ -61,4 +63,5 @@ srcs += files(
   'version.f90',
   'wavefunction.f90',
   'wignerseitz.f90',
+  'xtb.f90',
 )

--- a/src/tblite/ncoord.f90
+++ b/src/tblite/ncoord.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/ncoord
+!> Contains the implementation for the coordination number evaluators.
+
+!> @file tblite/ncoord.f90
+!> Reexports the coordination number evaluation modules.
+
 !> Proxy module to expose coordination number containers
 module tblite_ncoord
    use mctc_env, only : wp

--- a/src/tblite/ncoord/exp.f90
+++ b/src/tblite/ncoord/exp.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/ncoord/exp.f90
 module tblite_ncoord_exp
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/ncoord/exp.f90
+++ b/src/tblite/ncoord/exp.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/ncoord/exp.f90
+!> Provides a coordination number implementation with exponential counting function
+
+!> Coordination number implementation using an exponential counting function
 module tblite_ncoord_exp
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -25,9 +28,10 @@ module tblite_ncoord_exp
    implicit none
    private
 
-   public :: exp_ncoord_type, new_exp_ncoord
+   public :: new_exp_ncoord
 
-   type, extends(ncoord_type) :: exp_ncoord_type
+   !> Coordination number evaluator
+   type, public, extends(ncoord_type) :: exp_ncoord_type
       real(wp) :: cutoff
       real(wp), allocatable :: rcov(:)
    contains

--- a/src/tblite/ncoord/gfn.f90
+++ b/src/tblite/ncoord/gfn.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/ncoord/gfn.f90
+!> Provides a coordination number implementation with double exponential counting function
+
+!> Coordination number implementation using a double exponential counting function
 module tblite_ncoord_gfn
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -24,10 +27,11 @@ module tblite_ncoord_gfn
    implicit none
    private
 
-   public :: gfn_ncoord_type, new_gfn_ncoord
+   public :: new_gfn_ncoord
    public :: get_coordination_number
 
-   type, extends(ncoord_type) :: gfn_ncoord_type
+   !> Coordination number evaluator
+   type, public, extends(ncoord_type) :: gfn_ncoord_type
       real(wp) :: cutoff
       real(wp), allocatable :: rcov(:)
    contains

--- a/src/tblite/ncoord/gfn.f90
+++ b/src/tblite/ncoord/gfn.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/ncoord/gfn.f90
 module tblite_ncoord_gfn
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/ncoord/type.f90
+++ b/src/tblite/ncoord/type.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/ncoord/type.f90
 module tblite_ncoord_type
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/ncoord/type.f90
+++ b/src/tblite/ncoord/type.f90
@@ -15,15 +15,17 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/ncoord/type.f90
+!> Provides a coordination number evalulator base class
+
+!> Declaration of base class for coordination number evalulations
 module tblite_ncoord_type
    use mctc_env, only : wp
    use mctc_io, only : structure_type
    implicit none
    private
 
-   public :: ncoord_type
-
-   type, abstract :: ncoord_type
+   !> Abstract base class for coordination number evaluator
+   type, public, abstract :: ncoord_type
    contains
       procedure(get_cn), deferred :: get_cn
    end type ncoord_type

--- a/src/tblite/os.F90
+++ b/src/tblite/os.F90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/os.F90
+!> Provides operating system dependent functionality.
+
+!> Interfaces to the system libraries.
 module tblite_os
    use, intrinsic :: iso_c_binding, only : c_char, c_null_char, c_int
    implicit none

--- a/src/tblite/output/ascii.f90
+++ b/src/tblite/output/ascii.f90
@@ -14,7 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/output
+!> Contains routines for terminal or string output generation
+
 !> @file tblite/output/ascii.f90
+!> Provides routines for terminal or text file output
+
+!> Implementation of terminal or text file output
 module tblite_output_ascii
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/output/ascii.f90
+++ b/src/tblite/output/ascii.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/output/ascii.f90
 module tblite_output_ascii
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/output/format.f90
+++ b/src/tblite/output/format.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/output/format.f90
 module tblite_output_format
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/output/format.f90
+++ b/src/tblite/output/format.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/output/format.f90
+!> Provides conversion routines from intrinsic data types to string
+
+!> Functional procedures for creating strings from intrinsic data types
 module tblite_output_format
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/output/property.f90
+++ b/src/tblite/output/property.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/output/property.f90
 module tblite_output_property
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/output/property.f90
+++ b/src/tblite/output/property.f90
@@ -15,14 +15,17 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/output/property.f90
+!> Provides helper routines to print properties together with units
+
+!> Simple derived type with formatted IO procedure to provide simple debug printing
 module tblite_output_property
    use mctc_env, only : wp
    implicit none
    private
 
-   public :: property, write(formatted)
+   public :: write(formatted)
 
-   type :: property
+   type, public :: property
       character(len=:), allocatable :: label
       real(wp) :: value
       character(len=:), allocatable :: unit

--- a/src/tblite/param.f90
+++ b/src/tblite/param.f90
@@ -14,6 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/param
+!> Definition of the individual components of the parametrization data.
+
+!> @file tblite/param.f90
+!> Reexport of the parametrization records and definition of the high-level representation
+!> if the parametrization data format.
+
 !> Defininition of the parametrization data format
 module tblite_param
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/charge.f90
+++ b/src/tblite/param/charge.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/charge.f90
+!> Provides model for the isotropic second-order electrostatic
+
 !> Definition of the isotropic second-order electrostatic model
 module tblite_param_charge
    use mctc_env, only : wp, error_type, fatal_error
@@ -24,14 +26,14 @@ module tblite_param_charge
    implicit none
    private
 
-   public :: charge_record, charge_mask, count
+   public :: count
 
 
    character(len=*), parameter :: k_effective = "effective", k_gexp = "gexp", &
       & k_average = "average", k_gamma = "gamma"
 
    !> Parametrization record for the isotropic second-order electrostatics
-   type, extends(serde_record) :: charge_record
+   type, public, extends(serde_record) :: charge_record
       !> Coulomb interaction kernel
       integer :: kernel
       !> Averaging scheme for the chemical hardness / Hubbard parameters
@@ -52,7 +54,8 @@ module tblite_param_charge
    end type
 
 
-   type :: charge_mask
+   !> Masking for the isotropic electrostatic model
+   type, public :: charge_mask
    end type charge_mask
 
 

--- a/src/tblite/param/charge.f90
+++ b/src/tblite/param/charge.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/charge.f90
 !> Definition of the isotropic second-order electrostatic model
 module tblite_param_charge
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/dispersion.f90
+++ b/src/tblite/param/dispersion.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/dispersion.f90
 !> Definition of the dispersion corrections
 module tblite_param_dispersion
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/dispersion.f90
+++ b/src/tblite/param/dispersion.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/dispersion.f90
+!> Provides model for the dispersion corrections
+
 !> Definition of the dispersion corrections
 module tblite_param_dispersion
    use mctc_env, only : wp, error_type, fatal_error
@@ -24,14 +26,14 @@ module tblite_param_dispersion
    implicit none
    private
 
-   public :: dispersion_record, dispersion_mask, count
+   public :: count
 
 
    character(len=*), parameter :: k_d3 = "d3", k_d4 = "d4", k_sc = "sc", &
       & k_s6 = "s6", k_s8 = "s8", k_s9 = "s9", k_a1 = "a1", k_a2 = "a2"
 
    !> Parametrization record specifying the dispersion model
-   type, extends(serde_record) :: dispersion_record
+   type, public, extends(serde_record) :: dispersion_record
       !> Scaling for dipole-dipole (C6) interactions
       real(wp) :: s6
       !> Scaling for dipole-quadrupole (C6) interactions
@@ -60,7 +62,8 @@ module tblite_param_dispersion
    end type
 
 
-   type :: dispersion_mask
+   !> Masking for the dispersion model
+   type, public :: dispersion_mask
    end type dispersion_mask
 
 

--- a/src/tblite/param/element.f90
+++ b/src/tblite/param/element.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/element.f90
+!> Provides records for the element specific parameters
+
 !> Definition of the element specific parameter records
 module tblite_param_element
    use mctc_env, only : wp, error_type, fatal_error
@@ -25,7 +27,7 @@ module tblite_param_element
    implicit none
    private
 
-   public :: element_record, element_mask, count
+   public :: count
 
 
    !> The conversion factor from eV to Hartree is used for compatibility with older
@@ -43,7 +45,7 @@ module tblite_param_element
       & k_mpvcn = "mpvcn", k_xbond = "xbond", k_en = "en"
 
    !> Representation of the element specific parameters
-   type, extends(serde_record) :: element_record
+   type, public, extends(serde_record) :: element_record
       !> Element symbol of specie represented by this record
       character(len=symbol_length) :: sym = ''
       !> Atomic number of the specie represented by this record
@@ -109,7 +111,8 @@ module tblite_param_element
    end type
 
 
-   type :: element_mask
+   !> Masking for the element record
+   type, public :: element_mask
       !> Element symbol of specie represented by this record
       character(len=symbol_length) :: sym = ''
       !> Atomic number of the specie represented by this record

--- a/src/tblite/param/element.f90
+++ b/src/tblite/param/element.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/element.f90
 !> Definition of the element specific parameter records
 module tblite_param_element
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/halogen.f90
+++ b/src/tblite/param/halogen.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/halogen.f90
+!> Provides record for the halogen bonding model
+
+!> Defines model for the halogen bonding model
 module tblite_param_halogen
    use mctc_env, only : wp, error_type, fatal_error
    use tblite_param_serde, only : serde_record
@@ -22,12 +25,13 @@ module tblite_param_halogen
    implicit none
    private
 
-   public :: halogen_record, halogen_mask, count
+   public :: count
 
    character(len=*), parameter :: k_classical = "classical", k_damping = "damping", &
       & k_rscale = "rscale"
 
-   type, extends(serde_record) :: halogen_record
+   !> Parametrization model for the halogen bonding
+   type, public, extends(serde_record) :: halogen_record
       real(wp) :: damping
       real(wp) :: rscale
    contains
@@ -44,7 +48,8 @@ module tblite_param_halogen
    end type
 
 
-   type :: halogen_mask
+   !> Masking for the halogen bonding model
+   type, public :: halogen_mask
    end type halogen_mask
 
 

--- a/src/tblite/param/halogen.f90
+++ b/src/tblite/param/halogen.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/halogen.f90
 module tblite_param_halogen
    use mctc_env, only : wp, error_type, fatal_error
    use tblite_param_serde, only : serde_record

--- a/src/tblite/param/hamiltonian.f90
+++ b/src/tblite/param/hamiltonian.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/hamiltonian.f90
+!> Provides parameter record for the Hamiltonian
+
+!> Defines model for the Hamiltonian parameters
 module tblite_param_hamiltonian
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io_symbols, only : symbol_length
@@ -22,14 +26,16 @@ module tblite_param_hamiltonian
    implicit none
    private
 
-   public :: hamiltonian_record, hamiltonian_mask, count
+   public :: count
 
    character(len=*), parameter :: k_xtb = "xtb", k_ang(0:4) = ["s", "p", "d", "f", "g"], &
       & k_enscale = "enscale", k_shell = "shell", k_wexp = "wexp", k_cn = "cn", &
       & k_kpol = "kpol", k_kpair = "kpair"
    real(wp), parameter :: kpol_default = 2.0_wp
 
-   type, extends(serde_record) :: hamiltonian_record
+
+   !> Hamiltonian parametrization record
+   type, public, extends(serde_record) :: hamiltonian_record
       character(len=symbol_length), allocatable :: sym(:)
       character(len=:), allocatable :: cn
       real(wp), allocatable :: kpair(:, :)
@@ -52,7 +58,8 @@ module tblite_param_hamiltonian
    end type
 
 
-   type :: hamiltonian_mask
+   !> Masking for the Hamiltonian parameter record
+   type, public :: hamiltonian_mask
    end type hamiltonian_mask
 
 

--- a/src/tblite/param/mask.f90
+++ b/src/tblite/param/mask.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/mask.f90
+!> Provides a general mask for the complete parameters set
+
+!> Collection of the parameter masking
 module tblite_param_mask
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io_symbols, only : to_number, symbol_length
@@ -32,7 +35,7 @@ module tblite_param_mask
    implicit none
    private
 
-   public :: param_mask, count
+   public :: count
 
 
    type :: allowed_records
@@ -46,7 +49,8 @@ module tblite_param_mask
    end type allowed_records
 
 
-   type, extends(serde_record) :: param_mask
+   !> Definition of the complete parameter mask
+   type, public, extends(serde_record) :: param_mask
       !> Definition of the Hamiltonian, always required
       type(hamiltonian_mask), allocatable :: hamiltonian
       !> Definition of the dispersion correction

--- a/src/tblite/param/mask.f90
+++ b/src/tblite/param/mask.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/mask.f90
 module tblite_param_mask
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io_symbols, only : to_number, symbol_length

--- a/src/tblite/param/multipole.f90
+++ b/src/tblite/param/multipole.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/multipole.f90
 !> Definition of the anisotropic second-order electrostatic contributions
 module tblite_param_multipole
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/multipole.f90
+++ b/src/tblite/param/multipole.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/multipole.f90
+!> Provides a model for the anisotropic second-order electrostatic
+
 !> Definition of the anisotropic second-order electrostatic contributions
 module tblite_param_multipole
    use mctc_env, only : wp, error_type, fatal_error
@@ -23,14 +25,14 @@ module tblite_param_multipole
    implicit none
    private
 
-   public :: multipole_record, multipole_mask, count
+   public :: count
 
 
    character(len=*), parameter :: k_damped = "damped", k_dmp3 = "dmp3", k_dmp5 = "dmp5", &
       & k_kexp = "kexp", k_shift = "shift", k_rmax = "rmax"
 
    !> Representation of the multipolar electrostatics
-   type, extends(serde_record) :: multipole_record
+   type, public, extends(serde_record) :: multipole_record
       !> Damping exponent for quadratic terms
       real(wp) :: dmp3
       !> Damping exponent for cubic terms
@@ -55,7 +57,8 @@ module tblite_param_multipole
    end type
 
 
-   type :: multipole_mask
+   !> Masking for the anisotropic electrostatic parametrization
+   type, public :: multipole_mask
    end type multipole_mask
 
 

--- a/src/tblite/param/repulsion.f90
+++ b/src/tblite/param/repulsion.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/repulsion.f90
+!> Provides a module for the repulsion interactions
+
 !> Definition of the repulsion interactions
 module tblite_param_repulsion
    use mctc_env, only : wp, error_type, fatal_error
@@ -23,14 +25,14 @@ module tblite_param_repulsion
    implicit none
    private
 
-   public :: repulsion_record, repulsion_mask, count
+   public :: count
 
 
    character(len=*), parameter :: k_effective = "effective", k_kexp = "kexp", &
       & k_klight = "klight"
 
    !> Parametrization records describing the repulsion interactions
-   type, extends(serde_record) :: repulsion_record
+   type, public, extends(serde_record) :: repulsion_record
       real(wp) :: kexp
       real(wp) :: klight
    contains
@@ -47,7 +49,8 @@ module tblite_param_repulsion
    end type
 
 
-   type :: repulsion_mask
+   !> Provides a mask for the repulsion model
+   type, public :: repulsion_mask
    end type repulsion_mask
 
 

--- a/src/tblite/param/repulsion.f90
+++ b/src/tblite/param/repulsion.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/repulsion.f90
 !> Definition of the repulsion interactions
 module tblite_param_repulsion
    use mctc_env, only : wp, error_type, fatal_error

--- a/src/tblite/param/serde.f90
+++ b/src/tblite/param/serde.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/param/serde.f90
 !> Definition of a parameter record with serde properties.
 !> Each record knows how to serialize and deserialize itself.
 module tblite_param_serde

--- a/src/tblite/param/serde.f90
+++ b/src/tblite/param/serde.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/serde.f90
+!> Provides a base class for serializable and deserializable data
+
 !> Definition of a parameter record with serde properties.
 !> Each record knows how to serialize and deserialize itself.
 module tblite_param_serde
@@ -23,11 +25,9 @@ module tblite_param_serde
    implicit none
    private
 
-   public :: serde_record
-
 
    !> Serializable and deserializable parameter record
-   type, abstract :: serde_record
+   type, public, abstract :: serde_record
    contains
       !> Reading of parametrization data
       generic :: load => load_from_file, load_from_unit, load_from_toml

--- a/src/tblite/param/thirdorder.f90
+++ b/src/tblite/param/thirdorder.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/param/thirdorder.f90
+!> Provides a model for the isotropic third-order electrostatic
+
 !> Definition of the isotropic third-order electrostatic contributions.
 module tblite_param_thirdorder
    use mctc_env, only : wp, error_type, fatal_error
@@ -23,13 +25,13 @@ module tblite_param_thirdorder
    implicit none
    private
 
-   public :: thirdorder_record, thirdorder_mask, count
+   public :: count
 
 
    character(len=*), parameter :: k_shell = "shell", k_ang(0:4) = ["s", "p", "d", "f", "g"]
 
    !> Parametrization record for third-order electrostatic contributions
-   type, extends(serde_record) :: thirdorder_record
+   type, public, extends(serde_record) :: thirdorder_record
       integer :: lmax
       logical :: shell
       real(wp) :: ksh(0:4)
@@ -47,7 +49,8 @@ module tblite_param_thirdorder
    end type
 
 
-   type :: thirdorder_mask
+   !> Masking for the third order electrostatics
+   type, public :: thirdorder_mask
    end type thirdorder_mask
 
 

--- a/src/tblite/param/thirdorder.f90
+++ b/src/tblite/param/thirdorder.f90
@@ -14,7 +14,8 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> Definition of the isotropic third-order electrostatic contributions
+!> @file tblite/param/thirdorder.f90
+!> Definition of the isotropic third-order electrostatic contributions.
 module tblite_param_thirdorder
    use mctc_env, only : wp, error_type, fatal_error
    use tblite_param_serde, only : serde_record

--- a/src/tblite/repulsion.f90
+++ b/src/tblite/repulsion.f90
@@ -14,7 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> Proxy module for repulsion interactions
+!> @dir tblite/repulsion
+!> Contains the repulsive interaction implementations.
+
+!> @file tblite/repulsion.f90
+!> Reexport for the repulsion container implementations.
+
+!> Proxy module for repulsion interactions.
 module tblite_repulsion
    use tblite_repulsion_effective, only : tb_repulsion, new_repulsion
    use tblite_repulsion_type, only : repulsion_type

--- a/src/tblite/repulsion/effective.f90
+++ b/src/tblite/repulsion/effective.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/repulsion/effective.f90
+!> Provides a screened Coulomb repulsion interaction
+
 !> Classical repulsion interaction as used with the xTB Hamiltonian
 module tblite_repulsion_effective
    use mctc_env, only : wp
@@ -25,11 +27,11 @@ module tblite_repulsion_effective
    implicit none
    private
 
-   public :: tb_repulsion, new_repulsion
+   public :: new_repulsion
 
 
    !> Container to evaluate classical repulsion interactions for the xTB Hamiltonian
-   type, extends(repulsion_type) :: tb_repulsion
+   type, public, extends(repulsion_type) :: tb_repulsion
       !> Exponent for the repulsion interaction
       real(wp), allocatable :: alpha(:, :)
       !> Effective nuclear charge

--- a/src/tblite/repulsion/effective.f90
+++ b/src/tblite/repulsion/effective.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/repulsion/effective.f90
 !> Classical repulsion interaction as used with the xTB Hamiltonian
 module tblite_repulsion_effective
    use mctc_env, only : wp

--- a/src/tblite/repulsion/type.f90
+++ b/src/tblite/repulsion/type.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/repulsion/type.f90
 !> Definition of the abstract base class for classical interactions.
 module tblite_repulsion_type
    use mctc_env, only : wp

--- a/src/tblite/repulsion/type.f90
+++ b/src/tblite/repulsion/type.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/repulsion/type.f90
+!> Provides a base class for repulsion interactions
+
 !> Definition of the abstract base class for classical interactions.
 module tblite_repulsion_type
    use mctc_env, only : wp
@@ -23,13 +25,11 @@ module tblite_repulsion_type
    implicit none
    private
 
-   public :: repulsion_type
-
    !> Abstract base class for classical interactions, like repulsion interactions.
    !>
    !> This class provides a method to retrieve the contributions to the energy,
    !> gradient and virial within a given cutoff.
-   type, extends(container_type), abstract :: repulsion_type
+   type, public, extends(container_type), abstract :: repulsion_type
    end type repulsion_type
 
 end module tblite_repulsion_type

--- a/src/tblite/results.f90
+++ b/src/tblite/results.f90
@@ -14,7 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> Container for holding results produced by a calculation
+!> @file tblite/results.f90
+!> Provides a container for storing additional calculation results.
+
+!> Container for holding results produced by a calculation.
 module tblite_results
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/results.f90
+++ b/src/tblite/results.f90
@@ -23,11 +23,9 @@ module tblite_results
    implicit none
    private
 
-   public :: results_type
-
 
    !> Results container
-   type results_type
+   type, public :: results_type
       !> Atom-resolved energies
       real(wp), allocatable :: energies(:)
       !> Overlap integrals

--- a/src/tblite/scf.f90
+++ b/src/tblite/scf.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/scf
+!> Contains the implementation for the self-consistent field iterations
+
+!> @file tblite/scf.f90
+!> Reexports the self-consistent field iteration related functionality.
+
 !> Proxy module for rexports from SCF related modules
 module tblite_scf
    use tblite_scf_broyden, only : broyden_mixer, new_broyden

--- a/src/tblite/scf/broyden.f90
+++ b/src/tblite/scf/broyden.f90
@@ -15,15 +15,18 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/scf/broyden.f90
+!> Provides an electronic mixer implementation
+
+!> Implementation of a modified Broyden mixing
 module tblite_scf_broyden
    use mctc_env, only : wp
    use tblite_lapack, only : getrf, getrs
    implicit none
    private
 
-   public :: broyden_mixer, new_broyden, broyden
+   public :: new_broyden, broyden
 
-   type :: broyden_mixer
+   type, public :: broyden_mixer
       integer :: ndim
       integer :: memory
       integer :: iter

--- a/src/tblite/scf/broyden.f90
+++ b/src/tblite/scf/broyden.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/scf/broyden.f90
 module tblite_scf_broyden
    use mctc_env, only : wp
    use tblite_lapack, only : getrf, getrs

--- a/src/tblite/scf/info.f90
+++ b/src/tblite/scf/info.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/scf/info.f90
 module tblite_scf_info
    use mctc_env, only : sp, dp, error_type
    implicit none

--- a/src/tblite/scf/info.f90
+++ b/src/tblite/scf/info.f90
@@ -15,19 +15,23 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/scf/info.f90
+!> Provides a density dependence information
+
+!> Definition of information container on density dependence
 module tblite_scf_info
    use mctc_env, only : sp, dp, error_type
    implicit none
    private
 
-   public :: scf_info, not_used, atom_resolved, shell_resolved, orbital_resolved, max
+   public :: not_used, atom_resolved, shell_resolved, orbital_resolved, max
 
    integer, parameter :: not_used = 0
    integer, parameter :: atom_resolved = 1
    integer, parameter :: shell_resolved = 2
    integer, parameter :: orbital_resolved = 3
 
-   type :: scf_info
+   !> Small info container about density dependence
+   type, public :: scf_info
       integer :: charge = not_used
       integer :: dipole = not_used
       integer :: quadrupole = not_used

--- a/src/tblite/scf/iterator.f90
+++ b/src/tblite/scf/iterator.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/scf/iterator.f90
 module tblite_scf_iterator
    use mctc_env, only : wp, error_type
    use mctc_io, only : structure_type

--- a/src/tblite/scf/iterator.f90
+++ b/src/tblite/scf/iterator.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/scf/iterator.f90
+!> Provides the implementation of the actual self-consistent field iteractions
+
+!> Iterator for evaluating the Hamiltonian self-consistently
 module tblite_scf_iterator
    use mctc_env, only : wp, error_type
    use mctc_io, only : structure_type

--- a/src/tblite/scf/potential.f90
+++ b/src/tblite/scf/potential.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/scf/potential.f90
 !> Implementation of the density dependent potential and its contribution
 !> to the effective Hamiltonian
 module tblite_scf_potential

--- a/src/tblite/scf/potential.f90
+++ b/src/tblite/scf/potential.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/scf/potential.f90
+!> Defines a container for holding density dependent potentials
+
 !> Implementation of the density dependent potential and its contribution
 !> to the effective Hamiltonian
 module tblite_scf_potential
@@ -26,11 +28,11 @@ module tblite_scf_potential
    implicit none
    private
 
-   public :: potential_type, new_potential, add_pot_to_h1
+   public :: new_potential, add_pot_to_h1
 
 
    !> Container for density dependent potential-shifts
-   type :: potential_type
+   type, public :: potential_type
       !> Atom-resolved charge-dependent potential shift
       real(wp), allocatable :: vat(:, :)
       !> Shell-resolved charge-dependent potential shift

--- a/src/tblite/scf/solver.f90
+++ b/src/tblite/scf/solver.f90
@@ -15,14 +15,16 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/scf/solver.f90
+!> Provides a base class for defining electronic solvers
+
+!> Declaration of the abstract base class for electronic solvers
 module tblite_scf_solver
    use mctc_env, only : sp, dp, error_type
    implicit none
    private
 
-   public :: solver_type
-
-   type, abstract :: solver_type
+   !> Abstract base class for electronic solvers
+   type, public, abstract :: solver_type
    contains
       generic :: solve => solve_sp, solve_dp
       procedure(solve_sp), deferred :: solve_sp

--- a/src/tblite/scf/solver.f90
+++ b/src/tblite/scf/solver.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/scf/solver.f90
 module tblite_scf_solver
    use mctc_env, only : sp, dp, error_type
    implicit none

--- a/src/tblite/solvation.f90
+++ b/src/tblite/solvation.f90
@@ -14,6 +14,13 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/solvation
+!> Contains the implementation of the implicit solvation models.
+
+!> @file tblite/solvation.f90
+!> Provides reexports of the implict solvation model related implementations.
+
+!> Proxy module for implicit solvation models.
 module tblite_solvation
    use mctc_env, only : error_type, fatal_error
    use mctc_io, only : structure_type

--- a/src/tblite/solvation/alpb.f90
+++ b/src/tblite/solvation/alpb.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/alpb.f90
 !> Analytical linearized Poisson-Boltzmann solvation model.
 !>
 !> Implements a reaction field model of the Generalized Born type.

--- a/src/tblite/solvation/alpb.f90
+++ b/src/tblite/solvation/alpb.f90
@@ -15,7 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/alpb.f90
-!> Analytical linearized Poisson-Boltzmann solvation model.
+!> Provides the analytical linearized Poission-Boltzmann model.
+
+!> Analytical linearized Poisson-Boltzmann implicit solvation model.
 !>
 !> Implements a reaction field model of the Generalized Born type.
 module tblite_solvation_alpb
@@ -35,7 +37,7 @@ module tblite_solvation_alpb
    implicit none
    private
 
-   public :: alpb_solvation, new_alpb, alpb_input
+   public :: new_alpb
    public :: born_kernel
 
 
@@ -52,7 +54,7 @@ module tblite_solvation_alpb
 
 
    !> Input for ALPB solvation
-   type :: alpb_input
+   type, public :: alpb_input
       !> Dielectric constant
       real(wp) :: dielectric_const
       !> Scaling factor for Born radii
@@ -71,7 +73,7 @@ module tblite_solvation_alpb
 
 
    !> Definition of polarizable continuum model
-   type, extends(solvation_type) :: alpb_solvation
+   type, public, extends(solvation_type) :: alpb_solvation
       !> Dielectric function
       real(wp) :: keps
       !> Analytical linearized Poisson-Boltzmann constant

--- a/src/tblite/solvation/born.f90
+++ b/src/tblite/solvation/born.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/born.f90
 !> Integrator for Born radii
 module tblite_solvation_born
    use mctc_env, only : wp

--- a/src/tblite/solvation/born.f90
+++ b/src/tblite/solvation/born.f90
@@ -15,7 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/born.f90
-!> Integrator for Born radii
+!> Provides a Born radii integrator
+
+!> Integrator for Born radii based on the Onufriev-Bashford-Case model
 module tblite_solvation_born
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -25,10 +27,10 @@ module tblite_solvation_born
    implicit none
    private
 
-   public :: born_integrator, new_born_integrator
+   public :: new_born_integrator
 
    !> Implementation of GBOBC integrator
-   type :: born_integrator
+   type, public :: born_integrator
       !> van der Waals radii of the particles
       real(wp), allocatable :: vdwr(:)
       !> pair descreening approximation radii

--- a/src/tblite/solvation/cds.f90
+++ b/src/tblite/solvation/cds.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/cds.f90
 !> Cavity, dispersion and surface contribution to the solvation free energy
 module tblite_solvation_cds
    use mctc_env, only : wp

--- a/src/tblite/solvation/cds.f90
+++ b/src/tblite/solvation/cds.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/cds.f90
+!> Provides non-polar contributions to the solvation free energy
+
 !> Cavity, dispersion and surface contribution to the solvation free energy
 module tblite_solvation_cds
    use mctc_env, only : wp

--- a/src/tblite/solvation/cpcm.f90
+++ b/src/tblite/solvation/cpcm.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/cpcm.f90
+!> Provides a polarizable continuum model
+
+!> Implicit solvation model based on a polarizable dielectric continuum
 module tblite_solvation_cpcm
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type

--- a/src/tblite/solvation/cpcm.f90
+++ b/src/tblite/solvation/cpcm.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/cpcm.f90
 module tblite_solvation_cpcm
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type

--- a/src/tblite/solvation/cpcm_dd.f90
+++ b/src/tblite/solvation/cpcm_dd.f90
@@ -19,9 +19,10 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 !> @file tblite/solvation/cpcm_dd.f90
+!> Provides a domain decomposition solver for the conductor like screening model.
 !
-! A modular implementation of COSMO using a domain decomposition linear scaling
-! strategy.
+!> A modular implementation of COSMO using a domain decomposition linear scaling
+!> strategy.
 !
 ! This code is governed by the LGPL license and abiding by the rules of
 ! distribution of free software.

--- a/src/tblite/solvation/cpcm_dd.f90
+++ b/src/tblite/solvation/cpcm_dd.f90
@@ -18,6 +18,8 @@
 !                             ALL RIGHT RESERVED.                              !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
+!> @file tblite/solvation/cpcm_dd.f90
+!
 ! A modular implementation of COSMO using a domain decomposition linear scaling
 ! strategy.
 !

--- a/src/tblite/solvation/data.f90
+++ b/src/tblite/solvation/data.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/data.f90
 !> Element specific data for solvation models
 module tblite_solvation_data
    use mctc_env, only : wp

--- a/src/tblite/solvation/data.f90
+++ b/src/tblite/solvation/data.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/data.f90
+!> Provides element specific data
+
 !> Element specific data for solvation models
 module tblite_solvation_data
    use mctc_env, only : wp
@@ -24,10 +26,11 @@ module tblite_solvation_data
    private
 
    public :: get_vdw_rad_d3, get_vdw_rad_cosmo, get_vdw_rad_bondi
-   public :: get_solvent_data, solvent_data
+   public :: get_solvent_data
 
 
-   type :: solvent_data
+   !> Solvent specific parameters
+   type, public :: solvent_data
       real(wp) :: eps
       real(wp) :: n
       real(wp) :: alpha

--- a/src/tblite/solvation/input.f90
+++ b/src/tblite/solvation/input.f90
@@ -15,17 +15,18 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/input.f90
+!> Provides a collection of all input configurations
+
+!> Collection of the configuration types for all available implicit solvation models
 module tblite_solvation_input
    use tblite_solvation_alpb, only : alpb_input
    use tblite_solvation_cpcm, only : cpcm_input
    implicit none
    private
 
-   public :: solvation_input
-
 
    !> Collection of possible solvation models
-   type :: solvation_input
+   type, public :: solvation_input
       !> Input for CPCM solvation model
       type(cpcm_input), allocatable :: cpcm
       !> Input for ALPB solvation model

--- a/src/tblite/solvation/surface.f90
+++ b/src/tblite/solvation/surface.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/surface.f90
+!> Provides a surface integrator
+
 !> Surface integrator for solvent accessible surface area
 module tblite_solvation_surface
    use mctc_env, only : wp
@@ -26,9 +28,9 @@ module tblite_solvation_surface
    implicit none
    private
 
-   public :: surface_integrator, new_surface_integrator
+   public :: new_surface_integrator
 
-   type :: surface_integrator
+   type, public :: surface_integrator
       !> Number of angular grid points
       integer :: nang
       !> Angular grid coordinates

--- a/src/tblite/solvation/surface.f90
+++ b/src/tblite/solvation/surface.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/surface.f90
 !> Surface integrator for solvent accessible surface area
 module tblite_solvation_surface
    use mctc_env, only : wp

--- a/src/tblite/solvation/type.f90
+++ b/src/tblite/solvation/type.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/solvation/type.f90
 !> Definition of an abstract base class for defining solvation models
 module tblite_solvation_type
    use mctc_env, only : wp

--- a/src/tblite/solvation/type.f90
+++ b/src/tblite/solvation/type.f90
@@ -15,24 +15,17 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/solvation/type.f90
+!> Provides a base class for all implicit solvation models
+
 !> Definition of an abstract base class for defining solvation models
 module tblite_solvation_type
-   use mctc_env, only : wp
-   use mctc_io, only : structure_type
-   use tblite_blas, only : dot
-   use tblite_container_cache, only : container_cache
    use tblite_container_type, only : container_type
-   use tblite_scf_info, only : scf_info, atom_resolved
-   use tblite_scf_potential, only : potential_type
-   use tblite_wavefunction_type, only : wavefunction_type
    implicit none
    private
 
-   public :: solvation_type
-
 
    !> Abstract base class for solvation models
-   type, extends(container_type), abstract :: solvation_type
+   type, public, extends(container_type), abstract :: solvation_type
    end type solvation_type
 
 

--- a/src/tblite/spin.f90
+++ b/src/tblite/spin.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/spin.f90
+!> Provides spin-interactions for spin-polarized tight-binding calculations.
+
 !> Implementation of spin-interactions for spin-polarized tight-binding.
 !>
 !> The spin-components are represented as difference between alpha and beta population

--- a/src/tblite/timer.f90
+++ b/src/tblite/timer.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/timer.f90
+!> Provides a timer implementation for internal profiling
+
+!> Implementation of a timer class to obtain runtimes for code ranges
 module tblite_timer
    use mctc_env_accuracy, only : wp, i8
    use tblite_output_format, only : format_string

--- a/src/tblite/toml.f90
+++ b/src/tblite/toml.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/toml.f90
+!> Provides reexports of the [TOML Fortran](https://toml-f.readthedocs.io) modules
+
 !> Proxy module for TOML library implementation
 module tblite_toml
    use tomlf, only : toml_table, toml_array, toml_error, toml_serializer, toml_parse, &
@@ -26,9 +29,4 @@ module tblite_toml
    public :: toml_table, toml_array, toml_error, toml_serializer, toml_parse, toml_key, &
       & toml_value, len
    public :: get_value, set_value, add_table, add_array, merge_table
-
-
-
-contains
-
 end module tblite_toml

--- a/src/tblite/version.f90
+++ b/src/tblite/version.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/version.f90
+!> Provides version and feature information
+
+!> Interfaces to query the version information of the library.
 module tblite_version
    implicit none
    private

--- a/src/tblite/wavefunction.f90
+++ b/src/tblite/wavefunction.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @dir tblite/wavefunction
 !> Proxy module for wavefunction related types and procedures
 module tblite_wavefunction
    use tblite_wavefunction_guess, only : sad_guess, eeq_guess

--- a/src/tblite/wavefunction/fermi.f90
+++ b/src/tblite/wavefunction/fermi.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/wavefunction/fermi.f90
 module tblite_wavefunction_fermi
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/wavefunction/fermi.f90
+++ b/src/tblite/wavefunction/fermi.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/wavefunction/fermi.f90
+!> Provides a Fermi based electronic filling function
+
+!> Implementation of a Fermi distribution for filling the electronic levels
 module tblite_wavefunction_fermi
    use mctc_env, only : wp
    implicit none

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/wavefunction/guess.f90
+!> Provides guesses for the wavefunction
+
+!> Implementation of the guess wavefunctions
 module tblite_wavefunction_guess
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/wavefunction/guess.f90
 module tblite_wavefunction_guess
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/wavefunction/mulliken.f90
+++ b/src/tblite/wavefunction/mulliken.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/wavefunction/mulliken.f90
 module tblite_wavefunction_mulliken
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/wavefunction/spin.f90
+++ b/src/tblite/wavefunction/spin.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/wavefunction/spin.f90
 !> Handling of spin information in the wavefunction
 !>
 !> Spin is represented as charge and magnetization density in the population based

--- a/src/tblite/wavefunction/spin.f90
+++ b/src/tblite/wavefunction/spin.f90
@@ -15,6 +15,8 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/wavefunction/spin.f90
+!> Provides conversion routines to change the representation of spin-polarized densities
+
 !> Handling of spin information in the wavefunction
 !>
 !> Spin is represented as charge and magnetization density in the population based

--- a/src/tblite/wavefunction/type.f90
+++ b/src/tblite/wavefunction/type.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/wavefunction/type.f90
 !> Base model for the extended tight binding hamiltonian
 module tblite_wavefunction_type
    use mctc_env, only : wp

--- a/src/tblite/wavefunction/type.f90
+++ b/src/tblite/wavefunction/type.f90
@@ -15,17 +15,20 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/wavefunction/type.f90
-!> Base model for the extended tight binding hamiltonian
+!> Provides a wavefunction type for holding density-related information
+
+!> Declaration of a tight-binding wavefunction
 module tblite_wavefunction_type
    use mctc_env, only : wp
    use tblite_blas, only : gemm
    implicit none
    private
 
-   public :: wavefunction_type, new_wavefunction
+   public :: new_wavefunction
    public :: get_density_matrix, get_alpha_beta_occupation
 
-   type :: wavefunction_type
+   !> Tight-binding wavefunction
+   type, public :: wavefunction_type
       !> Electronic temperature
       real(wp) :: kt = 0.0_wp
       !> Number of electrons in this wavefunction

--- a/src/tblite/wignerseitz.f90
+++ b/src/tblite/wignerseitz.f90
@@ -15,6 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/xtb/wignerseitz.f90
+!> Provides a Wigner-Seitz cell
+
+!> Implementation of finding the relevant nearest neighbours in a Wigner-Seitz cell
 module tblite_wignerseitz
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -22,9 +25,10 @@ module tblite_wignerseitz
    implicit none
    private
 
-   public :: wignerseitz_cell, new_wignerseitz_cell
+   public :: new_wignerseitz_cell
 
-   type :: wignerseitz_cell
+   !> Information on Wigner-Seitz images
+   type, public :: wignerseitz_cell
       integer, allocatable :: nimg(:, :)
       integer, allocatable :: tridx(:, :, :)
       real(wp), allocatable :: trans(:, :)

--- a/src/tblite/wignerseitz.f90
+++ b/src/tblite/wignerseitz.f90
@@ -14,6 +14,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/wignerseitz.f90
 module tblite_wignerseitz
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/xtb.f90
+++ b/src/tblite/xtb.f90
@@ -1,0 +1,40 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> @dir tblite/xtb
+!> Routines related to the extend tight-binding Hamiltonian
+
+!> @file tblite/xtb.f90
+!> Proxy module for extended tight-binding Hamiltonian related settings
+
+!> This module contains reexports for the #xtb_calculator class and the
+!> possible parametrizations via #tblite_xtb_gfn1, #tblite_xtb_gfn2, and
+!> #tblite_xtb_ipea1. The main entry point for performing calculations is
+!> provided with #xtb_singlepoint.
+module tblite_xtb
+   use tblite_xtb_calculator, only : xtb_calculator, new_xtb_calculator, param_h0spec
+   use tblite_xtb_gfn1, only : new_gfn1_calculator, gfn1_h0spec, export_gfn1_param
+   use tblite_xtb_gfn2, only : new_gfn2_calculator, gfn2_h0spec, export_gfn2_param
+   use tblite_xtb_ipea1, only : new_ipea1_calculator, ipea1_h0spec, export_ipea1_param
+   use tblite_xtb_singlepoint, only : xtb_singlepoint
+   implicit none
+
+   public :: xtb_calculator, new_xtb_calculator, param_h0spec
+   public :: new_gfn1_calculator, gfn1_h0spec, export_gfn1_param
+   public :: new_gfn2_calculator, gfn2_h0spec, export_gfn2_param
+   public :: new_ipea1_calculator, ipea1_h0spec, export_ipea1_param
+   public :: xtb_singlepoint
+end module tblite_xtb

--- a/src/tblite/xtb.f90
+++ b/src/tblite/xtb.f90
@@ -20,10 +20,10 @@
 !> @file tblite/xtb.f90
 !> Proxy module for extended tight-binding Hamiltonian related settings
 
-!> This module contains reexports for the #xtb_calculator class and the
-!> possible parametrizations via #tblite_xtb_gfn1, #tblite_xtb_gfn2, and
+!> This module contains reexports for the #tblite_xtb_calculator::xtb_calculator class
+!> and the possible parametrizations via #tblite_xtb_gfn1, #tblite_xtb_gfn2, and
 !> #tblite_xtb_ipea1. The main entry point for performing calculations is
-!> provided with #xtb_singlepoint.
+!> provided with #tblite_xtb_singlepoint::xtb_singlepoint.
 module tblite_xtb
    use tblite_xtb_calculator, only : xtb_calculator, new_xtb_calculator, param_h0spec
    use tblite_xtb_gfn1, only : new_gfn1_calculator, gfn1_h0spec, export_gfn1_param

--- a/src/tblite/xtb/calculator.f90
+++ b/src/tblite/xtb/calculator.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/calculator.f90
+!> Provides the calculator type for holding xTB Hamiltonian parametrization.
+
+!> Implementation of calculator type for the extended-tight binding Hamiltonian.
+!> The #xtb_calculator collects the basic interactions required to perform a
+!> tight-binding calculation.
 module tblite_xtb_calculator
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
@@ -42,19 +48,33 @@ module tblite_xtb_calculator
    public :: xtb_calculator, new_xtb_calculator
    public :: param_h0spec
 
+   !> Default value for self-consistent iteration mixing
    real(wp), parameter :: mixer_damping_default = 0.4_wp
+
+   !> Default maximum number of self-consistent iterations
    integer, parameter :: max_iter_default = 250
 
-   type :: xtb_calculator
+   !> Extended tight-binding calculator
+   type, public :: xtb_calculator
+      !> Basis set definition
       type(basis_type) :: bas
+      !> Core Hamiltonian
       type(tb_hamiltonian) :: h0
+      !> Coordination number for modifying the self-energies
       class(ncoord_type), allocatable :: ncoord
+      !> Repulsion energy interactions
       type(tb_repulsion), allocatable :: repulsion
+      !> Collection of all Coulombic interactions
       type(tb_coulomb), allocatable :: coulomb
+      !> Halogen bonding correction
       type(halogen_correction), allocatable :: halogen
+      !> London-dispersion interaction
       class(dispersion_type), allocatable :: dispersion
+      !> Parameter for self-consistent iteration mixing
       real(wp) :: mixer_damping = mixer_damping_default
+      !> Maximum number of self-consistent iteractions
       integer :: max_iter = max_iter_default
+      !> Store calculated integral intermediates
       logical :: save_integrals = .false.
       !> List of additional interaction containers
       type(container_list), allocatable :: interactions
@@ -88,6 +108,7 @@ module tblite_xtb_calculator
       procedure :: get_reference_occ
    end type param_h0spec
 
+   !> Constructor for Hamiltonian specification
    interface param_h0spec
       module procedure :: new_param_h0spec
    end interface param_h0spec
@@ -96,6 +117,7 @@ module tblite_xtb_calculator
 contains
 
 
+!> Create new xTB Hamiltonian calculator from parametrization data
 subroutine new_xtb_calculator(calc, mol, param, error)
    !> Instance of the xTB calculator
    type(xtb_calculator), intent(out) :: calc

--- a/src/tblite/xtb/calculator.f90
+++ b/src/tblite/xtb/calculator.f90
@@ -45,7 +45,7 @@ module tblite_xtb_calculator
    implicit none
    private
 
-   public :: xtb_calculator, new_xtb_calculator
+   public :: new_xtb_calculator
    public :: param_h0spec
 
    !> Default value for self-consistent iteration mixing

--- a/src/tblite/xtb/coulomb.f90
+++ b/src/tblite/xtb/coulomb.f90
@@ -14,14 +14,15 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/coulomb.f90
+!> Provides a collection for all Coulomb related interactions
+
+!> Collects all Coulomb related interaction in as single interaction container.
 module tblite_xtb_coulomb
    use mctc_env, only : wp
    use mctc_io, only : structure_type
-   use tblite_container_cache, only : container_cache
-   use tblite_container_type, only : container_type
-   use tblite_coulomb_charge, only : coulomb_charge_type
-   use tblite_coulomb_multipole, only : damped_multipole
-   use tblite_coulomb_thirdorder, only : onsite_thirdorder
+   use tblite_container, only : container_cache, container_type
+   use tblite_coulomb, only : coulomb_charge_type, damped_multipole, onsite_thirdorder
    use tblite_scf_potential, only : potential_type
    use tblite_wavefunction_type, only : wavefunction_type
    implicit none
@@ -29,9 +30,13 @@ module tblite_xtb_coulomb
 
    public :: tb_coulomb
 
-   type, extends(container_type) :: tb_coulomb
+   !> Collection of Coulombic interactions
+   type, public, extends(container_type) :: tb_coulomb
+      !> Isotroptic second-order electrostatics
       class(coulomb_charge_type), allocatable :: es2
+      !> Anisotropic second-order electrostatic
       type(damped_multipole), allocatable :: aes2
+      !> Onsite third-order electrostatic
       type(onsite_thirdorder), allocatable :: es3
    contains
       procedure :: update

--- a/src/tblite/xtb/coulomb.f90
+++ b/src/tblite/xtb/coulomb.f90
@@ -28,8 +28,6 @@ module tblite_xtb_coulomb
    implicit none
    private
 
-   public :: tb_coulomb
-
    !> Collection of Coulombic interactions
    type, public, extends(container_type) :: tb_coulomb
       !> Isotroptic second-order electrostatics

--- a/src/tblite/xtb/gfn1.f90
+++ b/src/tblite/xtb/gfn1.f90
@@ -41,7 +41,7 @@ module tblite_xtb_gfn1
    private
 
    public :: new_gfn1_calculator
-   public :: gfn1_h0spec, export_gfn1_param
+   public :: export_gfn1_param
 
    integer, parameter :: max_elem = 86
    integer, parameter :: max_shell = 3

--- a/src/tblite/xtb/gfn1.f90
+++ b/src/tblite/xtb/gfn1.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/gfn1.f90
+!> Provides the parametrization for the GFN1-xTB Hamiltonian
+
+!> Implementation of the GFN1-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_gfn1
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -487,7 +491,7 @@ module tblite_xtb_gfn1
       & 0.000000_wp]
 
    !> Specification of the GFN1-xTB effective Hamiltonian
-   type, extends(tb_h0spec) :: gfn1_h0spec
+   type, public, extends(tb_h0spec) :: gfn1_h0spec
       real(wp) :: kshell(0:2, 0:2)
       real(wp), allocatable :: kpair(:, :)
       logical, allocatable :: valence(:, :)

--- a/src/tblite/xtb/gfn2.f90
+++ b/src/tblite/xtb/gfn2.f90
@@ -40,7 +40,7 @@ module tblite_xtb_gfn2
    private
 
    public :: new_gfn2_calculator
-   public :: gfn2_h0spec, export_gfn2_param
+   public :: export_gfn2_param
 
 
    integer, parameter :: max_elem = 86

--- a/src/tblite/xtb/gfn2.f90
+++ b/src/tblite/xtb/gfn2.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/gfn2.f90
+!> Provides the parametrization for the GFN2-xTB Hamiltonian
+
+!> Implementation of the GFN2-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_gfn2
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -539,7 +543,7 @@ module tblite_xtb_gfn2
 
 
    !> Specification of the
-   type, extends(tb_h0spec) :: gfn2_h0spec
+   type, public, extends(tb_h0spec) :: gfn2_h0spec
       real(wp) :: kshell(0:2, 0:2)
       real(wp), allocatable :: kpair(:, :)
    contains

--- a/src/tblite/xtb/h0.f90
+++ b/src/tblite/xtb/h0.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/h0.f90
+!> Provides the effective core Hamiltonian for xTB.
+
 !> Implementation of the effective core Hamiltonian used in the extended tight binding.
 module tblite_xtb_h0
    use mctc_env, only : wp
@@ -30,7 +33,7 @@ module tblite_xtb_h0
    public :: get_selfenergy, get_hamiltonian, get_occupation, get_hamiltonian_gradient
 
 
-   type :: tb_hamiltonian
+   type, public :: tb_hamiltonian
       !> Atomic level information
       real(wp), allocatable :: selfenergy(:, :)
       !> Coordination number dependence of the atomic levels

--- a/src/tblite/xtb/h0.f90
+++ b/src/tblite/xtb/h0.f90
@@ -29,7 +29,7 @@ module tblite_xtb_h0
    implicit none
    private
 
-   public :: tb_hamiltonian, new_hamiltonian
+   public ::  new_hamiltonian
    public :: get_selfenergy, get_hamiltonian, get_occupation, get_hamiltonian_gradient
 
 

--- a/src/tblite/xtb/ipea1.f90
+++ b/src/tblite/xtb/ipea1.f90
@@ -14,6 +14,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/ipea1.f90
+!> Provides the parametrization for the IPEA1-xTB Hamiltonian
+
+!> Implementation of the IPEA1-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_ipea1
    use mctc_env, only : wp
    use mctc_io, only : structure_type
@@ -497,7 +501,7 @@ module tblite_xtb_ipea1
       &        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]  ! Lu-Rn
 
    !> Specification of the IPEA1-xTB effective Hamiltonian
-   type, extends(tb_h0spec) :: ipea1_h0spec
+   type, public, extends(tb_h0spec) :: ipea1_h0spec
       real(wp) :: kshell(0:2, 0:2)
       real(wp), allocatable :: kpair(:, :)
       logical, allocatable :: valence(:, :)

--- a/src/tblite/xtb/ipea1.f90
+++ b/src/tblite/xtb/ipea1.f90
@@ -41,7 +41,7 @@ module tblite_xtb_ipea1
    private
 
    public :: new_ipea1_calculator
-   public :: ipea1_h0spec, export_ipea1_param
+   public :: export_ipea1_param
 
    integer, parameter :: max_elem = 86
    integer, parameter :: max_shell = 3

--- a/src/tblite/xtb/singlepoint.f90
+++ b/src/tblite/xtb/singlepoint.f90
@@ -14,6 +14,12 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/singlepoint.f90
+!> Provides main entry point for performing single point calculations with
+!> a #xtb_calculator instance.
+
+!> Implementation of the single point calculation for a self-consistent
+!> extended tight-binding Hamiltonian.
 module tblite_xtb_singlepoint
    use mctc_env, only : wp, error_type, fatal_error, get_variable
    use mctc_io, only : structure_type
@@ -57,17 +63,28 @@ module tblite_xtb_singlepoint
 contains
 
 
+!> Entry point for performing single point calculation using the xTB calculator
 subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigma, &
       & verbosity, results)
+   !> Calculation context
    type(context_type), intent(inout) :: ctx
+   !> Molecular structure data
    type(structure_type), intent(in) :: mol
+   !> Single-point calculator
    type(xtb_calculator), intent(in) :: calc
+   !> Wavefunction data
    type(wavefunction_type), intent(inout) :: wfn
+   !> Accuracy for computation
    real(wp), intent(in) :: accuracy
+   !> Total energy
    real(wp), intent(out) :: energy
+   !> Gradient with respect to cartesian coordinates
    real(wp), contiguous, intent(out), optional :: gradient(:, :)
+   !> Strain derivatives with respect to strain deformations
    real(wp), contiguous, intent(out), optional :: sigma(:, :)
+   !> Verbosity level of output
    integer, intent(in), optional :: verbosity
+   !> Container for storing additional results
    type(results_type), intent(out), optional :: results
 
    logical :: grad, converged, econverged, pconverged

--- a/src/tblite/xtb/spec.f90
+++ b/src/tblite/xtb/spec.f90
@@ -14,6 +14,9 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
+!> @file tblite/xtb/spec.f90
+!> Provides generator base class for Hamiltonian parameters.
+
 !> Definition of an abstract base class of the generator for the Hamiltonian.
 module tblite_xtb_spec
    use mctc_env, only : wp
@@ -30,7 +33,7 @@ module tblite_xtb_spec
    !>
    !> An instance of the specification is consumed by the constructor of the
    !> Hamiltonian to generate the respective entries in the derived type.
-   type, abstract :: tb_h0spec
+   type, public, abstract :: tb_h0spec
    contains
       !> Generator for the self energy / atomic levels of the Hamiltonian
       procedure(get_selfenergy), deferred :: get_selfenergy

--- a/src/tblite/xtb/spec.f90
+++ b/src/tblite/xtb/spec.f90
@@ -26,8 +26,6 @@ module tblite_xtb_spec
    implicit none
    private
 
-   public :: tb_h0spec
-
 
    !> Specification of the effective Hamiltonian.
    !>


### PR DESCRIPTION
Big documentation restructuring for providing doxygen generated API documentation for the Fortran library.

Closes #60 