### PR TITLE
Enable ILP64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ if(NOT TARGET "OpenMP::OpenMP_Fortran")
   endif()
 endif()
 
+if(WITH_ILP64)
+  if(NOT (BLAS_LIBRARIES AND LAPACK_LIBRARIES))
+    message(FATAL_ERROR "WITH_ILP64 needs BLAS_LIBRARIES and LAPACK_LIBRARIES")
+  endif()
+  message(STATUS "Using LAPACK/BLAS ILP64 interface")
+endif()
+
 if(NOT TARGET "LAPACK::LAPACK")
   find_package("LAPACK" REQUIRED)
 endif()
@@ -102,6 +109,15 @@ target_include_directories(
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${module-dir}>
 )
+if(WITH_ILP64)
+  target_compile_definitions(
+    "${PROJECT_NAME}-lib"
+    PUBLIC -DIK=i8)
+else()
+  target_compile_definitions(
+    "${PROJECT_NAME}-lib"
+    PUBLIC -DIK=i4)
+endif()
 if(NOT EXISTS "${PROJECT_BINARY_DIR}/include")
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/include")
 endif()

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 option(WITH_API "Enable export of C-API" TRUE)
 option(WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" TRUE)
 option(WITH_TESTS "Enable compilation of unit tests" TRUE)
+option(WITH_ILP64 "Enable support for ILP64 BLAS/LAPACK calls" FALSE)
 if(NOT DEFINED "${PROJECT_NAME}-dependency-method")
   set(
     "${PROJECT_NAME}-dependency-method"

--- a/config/meson.build
+++ b/config/meson.build
@@ -42,6 +42,14 @@ elif fc_id == 'pgi' or fc_id == 'nvidia_hpc'
   )
 endif
 
+if get_option('ilp64')
+  ilp64 = true
+  add_project_arguments('-DIK=i8', language:'fortran')
+else
+  add_project_arguments('-DIK=i4', language:'fortran')
+  ilp64 = false
+endif
+
 if get_option('openmp')
   omp_dep = dependency('openmp')
   lib_deps += omp_dep
@@ -57,12 +65,12 @@ endif
 if lapack_vendor == 'mkl'
   mkl_dep = []
   if fc_id == 'intel'
-    mkl_dep += cc.find_library('mkl_intel_lp64')
+    mkl_dep += cc.find_library(ilp64 ? 'mkl_intel_ilp64' : 'mkl_intel_lp64')
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_intel_thread')
     endif
   elif fc_id == 'gcc'
-    mkl_dep += cc.find_library('mkl_gf_lp64')
+    mkl_dep += cc.find_library(ilp64 ? 'mkl_gf_ilp64' : 'mkl_gf_lp64')
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_gnu_thread')
     endif
@@ -80,33 +88,49 @@ elif lapack_vendor == 'mkl-rt'
   lib_deps += mkl_dep
 
 elif lapack_vendor == 'openblas'
-  openblas_dep = dependency('openblas', required: false)
+  openblas_dep = dependency(ilp64 ? 'openblas64' : 'openblas', required: false)
   if not openblas_dep.found()
-    openblas_dep = fc.find_library('openblas')
+    openblas_dep = fc.find_library(ilp64 ? 'openblas64' : 'openblas')
   endif
   lib_deps += openblas_dep
   if not fc.links('external dsytrs; call dsytrs(); end', dependencies: openblas_dep)
-    lapack_dep = dependency('lapack', required: false)
+    lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: false)
     if not lapack_dep.found()
-      lapack_dep = fc.find_library('lapack')
+      lapack_dep = fc.find_library(ilp64 ? 'lapack64' : 'lapack')
     endif
     lib_deps += lapack_dep
   endif
 
 elif lapack_vendor == 'custom'
-  foreach lib: get_option('custom_libraries')
-    lib_deps += fc.find_library(lib)
-  endforeach
+  custom_deps = []
+  libs = get_option('custom_libraries')
+  if libs[0].startswith('-L')
+    foreach lib: libs
+      if lib != libs[0]
+        custom_deps += fc.find_library(lib, dirs: libs[0].substring(2))
+      endif
+    endforeach
+  else
+    foreach lib: libs
+      custom_deps += fc.find_library(lib)
+    endforeach
+  endif
+  if (not fc.links('external dsytrs; call dsytrs(); end', dependencies: [custom_deps,omp_dep]))
+    error('Custom LAPACK libraries do not link')
+  elif (not fc.links('external dsytrs; call dgemm(); end', dependencies: [custom_deps,omp_dep]))
+    error('Custom BLAS libraries do not link')
+  endif
+  lib_deps += custom_deps
 
 else
-  lapack_dep = dependency('lapack', required: false)
+  lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: false)
   if not lapack_dep.found()
-    lapack_dep = fc.find_library('lapack')
+    lapack_dep = fc.find_library(ilp64 ? 'lapack64' : 'lapack')
   endif
   lib_deps += lapack_dep
-  blas_dep = dependency('blas', required: false)
+  blas_dep = dependency(ilp64 ? 'blas64' : 'blas', required: false)
   if not blas_dep.found()
-    blas_dep = fc.find_library('blas')
+    blas_dep = fc.find_library(ilp64 ? 'blas64' : 'blas')
   endif
   lib_deps += blas_dep
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -59,3 +59,11 @@ option(
   value: 'python3',
   description: 'Python version to link against.',
 )
+
+option(
+  'ilp64',
+  type: 'boolean',
+  value: false,
+  yield: true,
+  description: 'Enable BLAS/LAPACK ILP64 support.',
+)

--- a/src/tblite/blas/CMakeLists.txt
+++ b/src/tblite/blas/CMakeLists.txt
@@ -18,9 +18,9 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(
   APPEND srcs
-  "${dir}/level1.f90"
-  "${dir}/level2.f90"
-  "${dir}/level3.f90"
+  "${dir}/level1.F90"
+  "${dir}/level2.F90"
+  "${dir}/level3.F90"
 )
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/tblite/blas/level1.F90
+++ b/src/tblite/blas/level1.F90
@@ -18,8 +18,13 @@
 !> Provides interfactes to level 1 BLAS routines
 
 !> High-level interface to level 1 basic linear algebra subprogram operations
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_blas_level1
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -43,22 +48,22 @@ module tblite_blas_level1
    !> Uses unrolled loops for increments equal to one.
    interface blas_dot
       pure function sdot(n, x, incx, y, incy)
-         import :: sp
+         import :: sp, ik
          real(sp) :: sdot
          real(sp), intent(in) :: x(*)
          real(sp), intent(in) :: y(*)
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: n
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: n
       end function sdot
       pure function ddot(n, x, incx, y, incy)
-         import :: dp
+         import :: dp, ik
          real(dp) :: ddot
          real(dp), intent(in) :: x(*)
          real(dp), intent(in) :: y(*)
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: n
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: n
       end function ddot
    end interface blas_dot
 
@@ -70,7 +75,7 @@ function wrap_sdot(xvec, yvec) result(dot)
    real(sp) :: dot
    real(sp), intent(in) :: xvec(:)
    real(sp), intent(in) :: yvec(:)
-   integer :: incx, incy, n
+   integer(ik) :: incx, incy, n
    incx = 1
    incy = 1
    n = size(xvec)
@@ -82,7 +87,7 @@ function wrap_ddot(xvec, yvec) result(dot)
    real(dp) :: dot
    real(dp), intent(in) :: xvec(:)
    real(dp), intent(in) :: yvec(:)
-   integer :: incx, incy, n
+   integer(ik) :: incx, incy, n
    incx = 1
    incy = 1
    n = size(xvec)

--- a/src/tblite/blas/level2.F90
+++ b/src/tblite/blas/level2.F90
@@ -18,8 +18,13 @@
 !> Provides interfactes to level 2 BLAS routines
 
 !> High-level interface to level 2 basic linear algebra subprogram operations
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_blas_level2
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -63,32 +68,32 @@ module tblite_blas_level2
    !> m by n matrix.
    interface blas_gemv
       pure subroutine sgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
          real(sp), intent(in) :: a(lda, *)
          real(sp), intent(in) :: x(*)
          real(sp), intent(inout) :: y(*)
          real(sp), intent(in) :: alpha
          real(sp), intent(in) :: beta
          character(len=1), intent(in) :: trans
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine sgemv
       pure subroutine dgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
          real(dp), intent(in) :: a(lda, *)
          real(dp), intent(in) :: x(*)
          real(dp), intent(inout) :: y(*)
          real(dp), intent(in) :: alpha
          real(dp), intent(in) :: beta
          character(len=1), intent(in) :: trans
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine dgemv
    end interface blas_gemv
 
@@ -100,30 +105,30 @@ module tblite_blas_level2
    !> A is an n by n symmetric matrix.
    interface blas_symv
       pure subroutine ssymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
          real(sp), intent(in) :: a(lda, *)
          real(sp), intent(in) :: x(*)
          real(sp), intent(inout) :: y(*)
          character(len=1), intent(in) :: uplo
          real(sp), intent(in) :: alpha
          real(sp), intent(in) :: beta
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: n
       end subroutine ssymv
       pure subroutine dsymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
          real(dp), intent(in) :: a(lda, *)
          real(dp), intent(in) :: x(*)
          real(dp), intent(inout) :: y(*)
          character(len=1), intent(in) :: uplo
          real(dp), intent(in) :: alpha
          real(dp), intent(in) :: beta
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: n
       end subroutine dsymv
    end interface blas_symv
 
@@ -282,7 +287,7 @@ pure subroutine wrap_sgemv(amat, xvec, yvec, alpha, beta, trans)
    character(len=1), intent(in), optional :: trans
    real(sp) :: a, b
    character(len=1) :: tra
-   integer :: incx, incy, m, n, lda
+   integer(ik) :: incx, incy, m, n, lda
    if (present(alpha)) then
       a = alpha
    else
@@ -316,7 +321,7 @@ pure subroutine wrap_dgemv(amat, xvec, yvec, alpha, beta, trans)
    character(len=1), intent(in), optional :: trans
    real(dp) :: a, b
    character(len=1) :: tra
-   integer :: incx, incy, m, n, lda
+   integer(ik) :: incx, incy, m, n, lda
    if (present(alpha)) then
       a = alpha
    else
@@ -350,7 +355,7 @@ pure subroutine wrap_ssymv(amat, xvec, yvec, uplo, alpha, beta)
    real(sp), intent(in), optional :: beta
    character(len=1) :: ula
    real(sp) :: a, b
-   integer :: incx, incy, n, lda
+   integer(ik) :: incx, incy, n, lda
    if (present(alpha)) then
       a = alpha
    else
@@ -383,7 +388,7 @@ pure subroutine wrap_dsymv(amat, xvec, yvec, uplo, alpha, beta)
    real(dp), intent(in), optional :: beta
    character(len=1) :: ula
    real(dp) :: a, b
-   integer :: incx, incy, n, lda
+   integer(ik) :: incx, incy, n, lda
    if (present(alpha)) then
       a = alpha
    else

--- a/src/tblite/blas/level3.F90
+++ b/src/tblite/blas/level3.F90
@@ -18,8 +18,13 @@
 !> Provides interfactes to level 3 BLAS routines
 
 !> High-level interface to level 3 basic linear algebra subprogram operations
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_blas_level3
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -61,7 +66,10 @@ module tblite_blas_level3
    interface blas_gemm
       pure subroutine sgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, &
             & beta, c, ldc)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
+         integer(ik), intent(in) :: ldb
+         integer(ik), intent(in) :: ldc
          real(sp), intent(in) :: a(lda, *)
          real(sp), intent(in) :: b(ldb, *)
          real(sp), intent(inout) :: c(ldc, *)
@@ -69,16 +77,16 @@ module tblite_blas_level3
          character(len=1), intent(in) :: transb
          real(sp), intent(in) :: alpha
          real(sp), intent(in) :: beta
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: k
-         integer, intent(in) :: lda
-         integer, intent(in) :: ldb
-         integer, intent(in) :: ldc
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
+         integer(ik), intent(in) :: k
       end subroutine sgemm
       pure subroutine dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, &
             & beta, c, ldc)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
+         integer(ik), intent(in) :: ldb
+         integer(ik), intent(in) :: ldc
          real(dp), intent(in) :: a(lda, *)
          real(dp), intent(in) :: b(ldb, *)
          real(dp), intent(inout) :: c(ldc, *)
@@ -86,12 +94,9 @@ module tblite_blas_level3
          character(len=1), intent(in) :: transb
          real(dp), intent(in) :: alpha
          real(dp), intent(in) :: beta
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: k
-         integer, intent(in) :: lda
-         integer, intent(in) :: ldb
-         integer, intent(in) :: ldc
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
+         integer(ik), intent(in) :: k
       end subroutine dgemm
    end interface blas_gemm
 
@@ -109,7 +114,7 @@ pure subroutine wrap_sgemm(amat, bmat, cmat, transa, transb, alpha, beta)
    real(sp), intent(in), optional :: beta
    character(len=1) :: tra, trb
    real(sp) :: a, b
-   integer :: m, n, k, lda, ldb, ldc
+   integer(ik) :: m, n, k, lda, ldb, ldc
    if (present(alpha)) then
       a = alpha
    else
@@ -154,7 +159,7 @@ pure subroutine wrap_dgemm(amat, bmat, cmat, transa, transb, alpha, beta)
    real(dp), intent(in), optional :: beta
    character(len=1) :: tra, trb
    real(dp) :: a, b
-   integer :: m, n, k, lda, ldb, ldc
+   integer(ik) :: m, n, k, lda, ldb, ldc
    if (present(alpha)) then
       a = alpha
    else

--- a/src/tblite/blas/meson.build
+++ b/src/tblite/blas/meson.build
@@ -15,7 +15,7 @@
 # along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 srcs += files(
-  'level1.f90',
-  'level2.f90',
-  'level3.f90',
+  'level1.F90',
+  'level2.F90',
+  'level3.F90',
 )

--- a/src/tblite/lapack/CMakeLists.txt
+++ b/src/tblite/lapack/CMakeLists.txt
@@ -18,10 +18,10 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(
   APPEND srcs
-  "${dir}/getrf.f90"
-  "${dir}/getri.f90"
-  "${dir}/getrs.f90"
-  "${dir}/sygvd.f90"
+  "${dir}/getrf.F90"
+  "${dir}/getri.F90"
+  "${dir}/getrs.F90"
+  "${dir}/sygvd.F90"
 )
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/tblite/lapack/getrf.F90
+++ b/src/tblite/lapack/getrf.F90
@@ -18,8 +18,13 @@
 !> Provides wrappers for LU factorization routines
 
 !> Wrapper rountines for LU factorization
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_lapack_getrf
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -50,22 +55,22 @@ module tblite_lapack_getrf
    !> triangular (upper trapezoidal if m < n).
    interface lapack_getrf
       pure subroutine sgetrf(m, n, a, lda, ipiv, info)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
          real(sp), intent(inout) :: a(lda, *)
-         integer, intent(out) :: ipiv(*)
-         integer, intent(out) :: info
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(out) :: ipiv(*)
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine sgetrf
       pure subroutine dgetrf(m, n, a, lda, ipiv, info)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
          real(dp), intent(inout) :: a(lda, *)
-         integer, intent(out) :: ipiv(*)
-         integer, intent(out) :: info
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(out) :: ipiv(*)
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine dgetrf
    end interface lapack_getrf
 
@@ -73,9 +78,9 @@ contains
 
 subroutine wrap_sgetrf(amat, ipiv, info)
    real(sp), intent(inout) :: amat(:, :)
-   integer, intent(out) :: ipiv(:)
-   integer, intent(out) :: info
-   integer :: m, n, lda
+   integer(ik), intent(out) :: ipiv(:)
+   integer(ik), intent(out) :: info
+   integer(ik) :: m, n, lda
    lda = max(1, size(amat, 1))
    m = size(amat, 1)
    n = size(amat, 2)
@@ -85,9 +90,9 @@ end subroutine wrap_sgetrf
 
 subroutine wrap_dgetrf(amat, ipiv, info)
    real(dp), intent(inout) :: amat(:, :)
-   integer, intent(out) :: ipiv(:)
-   integer, intent(out) :: info
-   integer :: m, n, lda
+   integer(ik), intent(out) :: ipiv(:)
+   integer(ik), intent(out) :: info
+   integer(ik) :: m, n, lda
    lda = max(1, size(amat, 1))
    m = size(amat, 1)
    n = size(amat, 2)

--- a/src/tblite/lapack/getri.F90
+++ b/src/tblite/lapack/getri.F90
@@ -18,8 +18,13 @@
 !> Provides wrappers for computing a matrix inverse
 
 !> Wrappers to obtain the inverse of a matrix
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_lapack_getri
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -44,24 +49,24 @@ module tblite_lapack_getri
    !> inv(A)*L = inv(U) for inv(A).
    interface lapack_getri
       pure subroutine sgetri(n, a, lda, ipiv, work, lwork, info)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
          real(sp), intent(inout) :: a(lda, *)
-         integer, intent(in) :: ipiv(*)
-         integer, intent(out) :: info
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: ipiv(*)
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: n
          real(sp), intent(inout) :: work(*)
-         integer, intent(in) :: lwork
+         integer(ik), intent(in) :: lwork
       end subroutine sgetri
       pure subroutine dgetri(n, a, lda, ipiv, work, lwork, info)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
          real(dp), intent(inout) :: a(lda, *)
-         integer, intent(in) :: ipiv(*)
-         integer, intent(out) :: info
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: ipiv(*)
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: n
          real(dp), intent(inout) :: work(*)
-         integer, intent(in) :: lwork
+         integer(ik), intent(in) :: lwork
       end subroutine dgetri
    end interface lapack_getri
 
@@ -69,9 +74,9 @@ contains
 
 subroutine wrap_sgetri(amat, ipiv, info)
    real(sp), intent(inout) :: amat(:, :)
-   integer, intent(in) :: ipiv(:)
-   integer, intent(out) :: info
-   integer :: n, lda, lwork
+   integer(ik), intent(in) :: ipiv(:)
+   integer(ik), intent(out) :: info
+   integer(ik) :: n, lda, lwork
    real(sp), allocatable :: work(:)
    real(sp) :: test(1)
    lda = max(1, size(amat, 1))
@@ -88,9 +93,9 @@ end subroutine wrap_sgetri
 
 subroutine wrap_dgetri(amat, ipiv, info)
    real(dp), intent(inout) :: amat(:, :)
-   integer, intent(in) :: ipiv(:)
-   integer, intent(out) :: info
-   integer :: n, lda, lwork
+   integer(ik), intent(in) :: ipiv(:)
+   integer(ik), intent(out) :: info
+   integer(ik) :: n, lda, lwork
    real(dp), allocatable :: work(:)
    real(dp) :: test(1)
    lda = max(1, size(amat, 1))

--- a/src/tblite/lapack/getrs.F90
+++ b/src/tblite/lapack/getrs.F90
@@ -18,8 +18,13 @@
 !> Provides wrappers to solve a linear equation system
 
 !> Wrappers to solve a system of linear equations
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_lapack_getrs
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -42,28 +47,28 @@ module tblite_lapack_getrs
    !> by ?GETRF.
    interface lapack_getrs
       pure subroutine sgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
+         integer(ik), intent(in) :: ldb
          real(sp), intent(in) :: a(lda, *)
-         integer, intent(in) :: ipiv(*)
+         integer(ik), intent(in) :: ipiv(*)
          real(sp), intent(inout) :: b(ldb, *)
          character(len=1), intent(in) :: trans
-         integer, intent(out) :: info
-         integer, intent(in) :: n
-         integer, intent(in) :: nrhs
-         integer, intent(in) :: lda
-         integer, intent(in) :: ldb
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: n
+         integer(ik), intent(in) :: nrhs
       end subroutine sgetrs
       pure subroutine dgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
+         integer(ik), intent(in) :: ldb
          real(dp), intent(in) :: a(lda, *)
-         integer, intent(in) :: ipiv(*)
+         integer(ik), intent(in) :: ipiv(*)
          real(dp), intent(inout) :: b(ldb, *)
          character(len=1), intent(in) :: trans
-         integer, intent(out) :: info
-         integer, intent(in) :: n
-         integer, intent(in) :: nrhs
-         integer, intent(in) :: lda
-         integer, intent(in) :: ldb
+         integer(ik), intent(out) :: info
+         integer(ik), intent(in) :: n
+         integer(ik), intent(in) :: nrhs
       end subroutine dgetrs
    end interface lapack_getrs
 
@@ -72,11 +77,11 @@ contains
 subroutine wrap_sgetrs(amat, bmat, ipiv, info, trans)
    real(sp), intent(in) :: amat(:, :)
    real(sp), intent(inout) :: bmat(:, :)
-   integer, intent(in) :: ipiv(:)
-   integer, intent(out) :: info
+   integer(ik), intent(in) :: ipiv(:)
+   integer(ik), intent(out) :: info
    character(len=1), intent(in), optional :: trans
    character(len=1) :: tra
-   integer :: n, nrhs, lda, ldb
+   integer(ik) :: n, nrhs, lda, ldb
    if (present(trans)) then
       tra = trans
    else
@@ -93,11 +98,11 @@ end subroutine wrap_sgetrs
 subroutine wrap_dgetrs(amat, bmat, ipiv, info, trans)
    real(dp), intent(in) :: amat(:, :)
    real(dp), intent(inout) :: bmat(:, :)
-   integer, intent(in) :: ipiv(:)
-   integer, intent(out) :: info
+   integer(ik), intent(in) :: ipiv(:)
+   integer(ik), intent(out) :: info
    character(len=1), intent(in), optional :: trans
    character(len=1) :: tra
-   integer :: n, nrhs, lda, ldb
+   integer(ik) :: n, nrhs, lda, ldb
    if (present(trans)) then
       tra = trans
    else

--- a/src/tblite/lapack/meson.build
+++ b/src/tblite/lapack/meson.build
@@ -15,8 +15,8 @@
 # along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 srcs += files(
-  'getrf.f90',
-  'getri.f90',
-  'getrs.f90',
-  'sygvd.f90',
+  'getrf.F90',
+  'getri.F90',
+  'getrs.F90',
+  'sygvd.F90',
 )

--- a/src/tblite/scf/CMakeLists.txt
+++ b/src/tblite/scf/CMakeLists.txt
@@ -18,7 +18,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(
   APPEND srcs
-  "${dir}/broyden.f90"
+  "${dir}/broyden.F90"
   "${dir}/info.f90"
   "${dir}/iterator.f90"
   "${dir}/potential.f90"

--- a/src/tblite/scf/broyden.F90
+++ b/src/tblite/scf/broyden.F90
@@ -18,8 +18,13 @@
 !> Provides an electronic mixer implementation
 
 !> Implementation of a modified Broyden mixing
+
+#ifndef IK
+#define IK i4
+#endif
+
 module tblite_scf_broyden
-   use mctc_env, only : wp
+   use mctc_env, only : wp, ik => IK
    use tblite_lapack, only : getrf, getrs
    implicit none
    private
@@ -255,8 +260,8 @@ subroutine lineq(a, c)
    real(wp), intent(inout) :: a(:, :)
    real(wp), intent(inout) :: c(:, :)
 
-   integer info
-   integer, allocatable :: ipiv(:)
+   integer(ik) info
+   integer(ik), allocatable :: ipiv(:)
 
    allocate(ipiv(size(a, 1)))
    ! LU decomoposition of a general matrix

--- a/src/tblite/scf/meson.build
+++ b/src/tblite/scf/meson.build
@@ -15,7 +15,7 @@
 # along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 srcs += files(
-  'broyden.f90',
+  'broyden.F90',
   'info.f90',
   'iterator.f90',
   'potential.f90',


### PR DESCRIPTION
Enables ILP64 support. Needs needs grimme-lab/multicharge#16, dftd4/dftd4#166 and dftd3/simple-dftd3#22

CMake:
`-DWITH_ILP64 -DBLAS_LIBRARIES= -DLAPACK_LIBRARIES=`

meson:
```
-Dilp64=true -Dlapack=mkl -Ds-dftd3:blas=custom -Ds-dftd3:blas_libs=-L$MKLROOT/lib/intel64,mkl_intel_ilp64,mkl_intel_thread,mkl_core
```