### PR TITLE
Add verbosity option to ASE Calculator

### DIFF
--- a/python/tblite/ase.py
+++ b/python/tblite/ase.py
@@ -232,6 +232,7 @@ class TBLite(ase.calculators.calculator.Calculator):
                 "temperature", self.parameters.electronic_temperature * kB / Hartree
             )
             calc.set("max-iter", self.parameters.max_iterations)
+            calc.set("verbosity", self.parameters.verbosity)
 
         except RuntimeError:
             raise ase.calculators.calculator.InputError(

--- a/python/tblite/ase.py
+++ b/python/tblite/ase.py
@@ -56,6 +56,7 @@ class TBLite(ase.calculators.calculator.Calculator):
      electronic_temperature   300.0             Electronic temperatur in Kelvin
      max_iterations           250               Iterations for self-consistent evaluation
      cache_api                True              Reuse generate API objects (recommended)
+     verbosity                1                 Set verbosity of printout
     ======================== ================= ============================================
 
     Example
@@ -109,6 +110,7 @@ class TBLite(ase.calculators.calculator.Calculator):
         "max_iterations": 250,
         "electronic_temperature": 300.0,
         "cache_api": True,
+        "verbosity": 1,
     }
 
     _res = None


### PR DESCRIPTION
Current ASE-TBlite Calculator does not recognize `verbosity` option. I have enabled this option in ASE TBlite Calculator.