### PR TITLE
Add double dictionary

### DIFF
--- a/src/tblite/CMakeLists.txt
+++ b/src/tblite/CMakeLists.txt
@@ -52,7 +52,7 @@ list(
   "${dir}/coulomb.f90"
   "${dir}/cutoff.f90"
   "${dir}/data.f90"
-  "${dir}/dictionary.f90"
+  "${dir}/double_dictionary.f90"
   "${dir}/disp.f90"
   "${dir}/lapack.f90"
   "${dir}/ncoord.f90"

--- a/src/tblite/CMakeLists.txt
+++ b/src/tblite/CMakeLists.txt
@@ -52,6 +52,7 @@ list(
   "${dir}/coulomb.f90"
   "${dir}/cutoff.f90"
   "${dir}/data.f90"
+  "${dir}/dictionary.f90"
   "${dir}/disp.f90"
   "${dir}/lapack.f90"
   "${dir}/ncoord.f90"

--- a/src/tblite/dictionary.f90
+++ b/src/tblite/dictionary.f90
@@ -49,10 +49,47 @@ module tblite_double_dictionary
       procedure :: copy
       generic :: operator(+) => combine_dict
       procedure :: combine_dict
+      generic, public :: remove_entry => remove_entry_label, remove_entry_index
+      procedure :: remove_entry_label
+      procedure :: remove_entry_index
    end type double_dictionary_type
 
 
 contains
+
+subroutine remove_entry_index(self, index)
+   class(double_dictionary_type) :: self
+   integer :: index, old_n, i, it
+   type(double_dictionary_type) :: tmp
+
+   if (index > self%n) return
+   old_n = self%n
+   self%n = self%n - 1
+
+   tmp = self
+   deallocate(self%record)
+   allocate(self%record(self%n))
+   it = 1
+   do i = 1, old_n
+      if (i == index) cycle
+      self%record(it) = tmp%record(it)
+      it = it + 1
+   end do
+ 
+end subroutine
+
+subroutine remove_entry_label(self, label)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   type(double_dictionary_type) :: tmp
+   integer :: it 
+   it = return_label_index(self, label)
+   if (it /= 0) then
+      call self%remove_entry_index(it) 
+   else
+      return
+   end if
+end subroutine 
 
 function get_n_entries(self) result(n)
    class(double_dictionary_type) :: self
@@ -105,8 +142,6 @@ function combine_dict(self, dict2) result(new_dict)
    integer :: it, i, n_entries
 
    new_dict = self
-
-   n_entries = self%get_n_entries()
 
    associate(dict => dict2)
       n_entries = dict%get_n_entries()

--- a/src/tblite/dictionary.f90
+++ b/src/tblite/dictionary.f90
@@ -1,456 +1,456 @@
 module tblite_double_dictionary
-    use mctc_env_accuracy, only : wp, i8
-    implicit none
-    private
+   use mctc_env_accuracy, only : wp, i8
+   implicit none
+   private
 
-    public :: double_dictionary_type
- 
-    type :: double_record
-       character(len=:), allocatable :: label
-       real(wp), allocatable :: array1(:) 
-       real(wp), allocatable :: array2(:, :) 
-       real(wp), allocatable :: array3(:, :, :)
-    contains
-        generic :: assignment(=) => copy_record
-        procedure :: copy_record
-    end type double_record
- 
-    type :: double_dictionary_type
-       integer :: n = 0
-       type(double_record), allocatable :: record(:)
-    contains
-       generic, public :: initialize_entry => ini_label, ini_1d, ini_2d, ini_3d
-       procedure :: ini_label
-       procedure :: ini_1d
-       procedure :: ini_2d
-       procedure :: ini_3d
-       generic, public :: add_entry =>  add_1d, add_2d, add_3d 
-       procedure :: add_1d
-       procedure :: add_2d
-       procedure :: add_3d
-       !procedure :: update_entry ! label and array pair
-       generic, public :: get_entry =>  get_1d_index, get_2d_index, get_3d_index, get_1d_label, get_2d_label, get_3d_label !check
-       procedure :: get_1d_index
-       procedure :: get_2d_index
-       procedure :: get_3d_index
-       procedure :: get_1d_label
-       procedure :: get_2d_label
-       procedure :: get_3d_label
-       generic, public :: update_entry => update_1d, update_2d, update_3d
-       procedure :: update_1d
-       procedure :: update_2d
-       procedure :: update_3d
-       procedure, public :: get_label ! return label label
-       procedure :: push
-       procedure, public :: get_n_entries
-       generic, public :: concatenate => concatenate_overwrite
-       procedure :: concatenate_overwrite
-       generic :: assignment(=) => copy
-       procedure :: copy
-       generic :: operator(+) => combine_dict
-       procedure :: combine_dict
-    end type double_dictionary_type    
+   public :: double_dictionary_type
 
-    
+   type :: double_record
+      character(len=:), allocatable :: label
+      real(wp), allocatable :: array1(:)
+      real(wp), allocatable :: array2(:, :)
+      real(wp), allocatable :: array3(:, :, :)
+   contains
+      generic :: assignment(=) => copy_record
+      procedure :: copy_record
+   end type double_record
+
+   type :: double_dictionary_type
+      integer :: n = 0
+      type(double_record), allocatable :: record(:)
+   contains
+      generic, public :: initialize_entry => ini_label, ini_1d, ini_2d, ini_3d
+      procedure :: ini_label
+      procedure :: ini_1d
+      procedure :: ini_2d
+      procedure :: ini_3d
+      generic, public :: add_entry =>  add_1d, add_2d, add_3d
+      procedure :: add_1d
+      procedure :: add_2d
+      procedure :: add_3d
+      !procedure :: update_entry ! label and array pair
+      generic, public :: get_entry =>  get_1d_index, get_2d_index, get_3d_index, get_1d_label, get_2d_label, get_3d_label !check
+      procedure :: get_1d_index
+      procedure :: get_2d_index
+      procedure :: get_3d_index
+      procedure :: get_1d_label
+      procedure :: get_2d_label
+      procedure :: get_3d_label
+      generic, public :: update_entry => update_1d, update_2d, update_3d
+      procedure :: update_1d
+      procedure :: update_2d
+      procedure :: update_3d
+      procedure, public :: get_label ! return label label
+      procedure :: push
+      procedure, public :: get_n_entries
+      generic, public :: concatenate => concatenate_overwrite
+      procedure :: concatenate_overwrite
+      generic :: assignment(=) => copy
+      procedure :: copy
+      generic :: operator(+) => combine_dict
+      procedure :: combine_dict
+   end type double_dictionary_type
+
+
 contains
 
 function get_n_entries(self) result(n)
-    class(double_dictionary_type) :: self
-    integer :: n 
-    n = self%n
+   class(double_dictionary_type) :: self
+   integer :: n
+   n = self%n
 end function
 
 subroutine copy(to, from)
-    class(double_dictionary_type), intent(inout) :: to
-    type(double_dictionary_type), intent(in) :: from
-    integer :: n_entries, i
-    to%n = from%n
-    if (allocated(to%record)) deallocate(to%record)
-    allocate(to%record(size(from%record)))
-    n_entries = from%get_n_entries() 
-    
-    do i = 1, n_entries
-        to%record(i) = from%record(i)
-    end do
-    
-end 
+   class(double_dictionary_type), intent(inout) :: to
+   type(double_dictionary_type), intent(in) :: from
+   integer :: n_entries, i
+   to%n = from%n
+   if (allocated(to%record)) deallocate(to%record)
+   allocate(to%record(size(from%record)))
+   n_entries = from%get_n_entries()
+
+   do i = 1, n_entries
+      to%record(i) = from%record(i)
+   end do
+
+end subroutine
 
 subroutine copy_record(to, from)
-    class(double_record), intent(inout) :: to
-    type(double_record), intent(in) :: from
-    integer :: n_entries, it, i
-    if (allocated(to%label)) deallocate(to%label)
-    to%label = from%label
-    if (allocated(from%array1)) to%array1 = from%array1
-    if (allocated(from%array2)) to%array2 = from%array2
-    if (allocated(from%array3)) to%array3 = from%array3
-    
-end 
+   class(double_record), intent(inout) :: to
+   type(double_record), intent(in) :: from
+   integer :: n_entries, it, i
+   if (allocated(to%label)) deallocate(to%label)
+   to%label = from%label
+   if (allocated(from%array1)) to%array1 = from%array1
+   if (allocated(from%array2)) to%array2 = from%array2
+   if (allocated(from%array3)) to%array3 = from%array3
+
+end subroutine
 
 subroutine concatenate_overwrite(self, dict2)
-    class(double_dictionary_type) :: self
-    type(double_dictionary_type) :: dict2
+   class(double_dictionary_type) :: self
+   type(double_dictionary_type) :: dict2
 
-    type(double_dictionary_type) :: new_dict
-    integer :: it, i, n_entries
+   type(double_dictionary_type) :: new_dict
+   integer :: it, i, n_entries
 
-    self = self + dict2
+   self = self + dict2
 
 end subroutine
 
 function combine_dict(self, dict2) result(new_dict)
-    class(double_dictionary_type), intent(in) :: self
-    type(double_dictionary_type), intent(in) :: dict2
-    type(double_dictionary_type) :: new_dict
-    integer :: it, i, n_entries
+   class(double_dictionary_type), intent(in) :: self
+   type(double_dictionary_type), intent(in) :: dict2
+   type(double_dictionary_type) :: new_dict
+   integer :: it, i, n_entries
 
-    new_dict = self
+   new_dict = self
 
-    n_entries = self%get_n_entries() 
+   n_entries = self%get_n_entries()
 
-    associate(dict => dict2)
-        n_entries = dict%get_n_entries()
-        do i = 1, n_entries
-            call new_dict%push(dict%record(i)%label, it)
-            new_dict%record(it) = dict%record(i)
-        end do
-    end associate
+   associate(dict => dict2)
+      n_entries = dict%get_n_entries()
+      do i = 1, n_entries
+         call new_dict%push(dict%record(i)%label, it)
+         new_dict%record(it) = dict%record(i)
+      end do
+   end associate
 
 end function
 
 subroutine update_1d(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:)
-    integer :: it 
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:)
+   integer :: it
 
-    it = return_label_index(self, label)
-    if (it /= 0) then
-        associate(record => self%record(it))
-            if (allocated(record%array1)) deallocate(record%array1)
-            if (allocated(record%array2)) deallocate(record%array2)
-            if (allocated(record%array3)) deallocate(record%array3)
-            call move_alloc(array, record%array1)
-        end associate
-    else
-        return
-    end if
+   it = return_label_index(self, label)
+   if (it /= 0) then
+      associate(record => self%record(it))
+         if (allocated(record%array1)) deallocate(record%array1)
+         if (allocated(record%array2)) deallocate(record%array2)
+         if (allocated(record%array3)) deallocate(record%array3)
+         call move_alloc(array, record%array1)
+      end associate
+   else
+      return
+   end if
 end subroutine
 
 subroutine update_2d(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:, :)
-    integer :: it 
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:, :)
+   integer :: it
 
-    it = return_label_index(self, label)
-    if (it /= 0) then
-        associate(record => self%record(it))
-            if (allocated(record%array1)) deallocate(record%array1)
-            if (allocated(record%array2)) deallocate(record%array2)
-            if (allocated(record%array3)) deallocate(record%array3)
-            call move_alloc(array, record%array2)
-        end associate 
-    else
-        return
-    end if
+   it = return_label_index(self, label)
+   if (it /= 0) then
+      associate(record => self%record(it))
+         if (allocated(record%array1)) deallocate(record%array1)
+         if (allocated(record%array2)) deallocate(record%array2)
+         if (allocated(record%array3)) deallocate(record%array3)
+         call move_alloc(array, record%array2)
+      end associate
+   else
+      return
+   end if
 end subroutine
 
 subroutine update_3d(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:, :, :)
-    integer :: it 
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:, :, :)
+   integer :: it
 
-    it = return_label_index(self, label)
-    if (it /= 0) then
-        associate(record => self%record(it))
-            if (allocated(record%array1)) deallocate(record%array1)
-            if (allocated(record%array2)) deallocate(record%array2)
-            if (allocated(record%array3)) deallocate(record%array3)
-            call move_alloc(array, record%array3)
-        end associate
-    else
-        return
-    end if 
+   it = return_label_index(self, label)
+   if (it /= 0) then
+      associate(record => self%record(it))
+         if (allocated(record%array1)) deallocate(record%array1)
+         if (allocated(record%array2)) deallocate(record%array2)
+         if (allocated(record%array3)) deallocate(record%array3)
+         call move_alloc(array, record%array3)
+      end associate
+   else
+      return
+   end if
 end subroutine
 
 subroutine get_label(self, index, label)
-    class(double_dictionary_type) :: self
-    integer :: index
-    character(len=:), allocatable :: label
+   class(double_dictionary_type) :: self
+   integer :: index
+   character(len=:), allocatable :: label
 
-    if (index > self%n) return
-    if (allocated(label)) deallocate(label)
-    
-    label = self%record(index)%label
+   if (index > self%n) return
+   if (allocated(label)) deallocate(label)
+
+   label = self%record(index)%label
 end subroutine
 
 subroutine get_1d_label(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:) 
-    integer :: it
-    it = return_label_index(self, label)
-    if (it == 0) return
-    call self%get_entry(it, array)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:)
+   integer :: it
+   it = return_label_index(self, label)
+   if (it == 0) return
+   call self%get_entry(it, array)
 
 end subroutine
 
 subroutine get_2d_label(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:,:)
-    integer :: it
-    it = return_label_index(self, label)
-    if (it == 0) return
-    call self%get_entry(it, array)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:,:)
+   integer :: it
+   it = return_label_index(self, label)
+   if (it == 0) return
+   call self%get_entry(it, array)
 
 end subroutine
 
 subroutine get_3d_label(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:, :, :) 
-    integer :: it
-    it = return_label_index(self, label)
-    if (it == 0) return
-    call self%get_entry(it, array)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:, :, :)
+   integer :: it
+   it = return_label_index(self, label)
+   if (it == 0) return
+   call self%get_entry(it, array)
 
-end subroutine 
+end subroutine
 
 subroutine get_1d_index(self, index, array)
-    class(double_dictionary_type) :: self
-    integer :: index
-    real(wp), allocatable :: array(:)
+   class(double_dictionary_type) :: self
+   integer :: index
+   real(wp), allocatable :: array(:)
 
-    if (index > self%n) return
-    if (index <= 0) return
-    associate(rec => self%record(index))
-        if (allocated(rec%array1)) then
-            if (allocated(array)) deallocate(array)
-            allocate(array(size(rec%array1, dim = 1)))
-            array = rec%array1
-        else 
-            return
-        end if
-    end associate
+   if (index > self%n) return
+   if (index <= 0) return
+   associate(rec => self%record(index))
+      if (allocated(rec%array1)) then
+         if (allocated(array)) deallocate(array)
+         allocate(array(size(rec%array1, dim = 1)))
+         array = rec%array1
+      else
+         return
+      end if
+   end associate
 
 end subroutine
 
 subroutine get_2d_index(self, index, array)
-    class(double_dictionary_type) :: self
-    integer :: index
-    real(wp), allocatable :: array(:,:) 
+   class(double_dictionary_type) :: self
+   integer :: index
+   real(wp), allocatable :: array(:,:)
 
-    if (index > self%n) return
-    if (index <= 0) return
-    associate(rec => self%record(index))
-        if (allocated(rec%array2)) then
-            if (allocated(array)) deallocate(array)
-            allocate(array(size(rec%array2, dim = 1), size(rec%array2, dim = 2)))
-            array = rec%array2
-        else 
-            return
-        end if
-    end associate
-    
+   if (index > self%n) return
+   if (index <= 0) return
+   associate(rec => self%record(index))
+      if (allocated(rec%array2)) then
+         if (allocated(array)) deallocate(array)
+         allocate(array(size(rec%array2, dim = 1), size(rec%array2, dim = 2)))
+         array = rec%array2
+      else
+         return
+      end if
+   end associate
+
 end subroutine
 
 subroutine get_3d_index(self, index, array)
-    class(double_dictionary_type) :: self
-    integer :: index
-    real(wp), allocatable :: array(:, :, :) 
+   class(double_dictionary_type) :: self
+   integer :: index
+   real(wp), allocatable :: array(:, :, :)
 
-    if (index > self%n) return
-    if (index <= 0) return
-    associate(rec => self%record(index))
-        if (allocated(rec%array3)) then
-            if (allocated(array)) deallocate(array)
-            allocate(array(size(rec%array3, dim = 1), size(rec%array3, dim = 2), size(rec%array3, dim=3)))
-            array = rec%array3
-        else 
-            return
-        end if
-    end associate
+   if (index > self%n) return
+   if (index <= 0) return
+   associate(rec => self%record(index))
+      if (allocated(rec%array3)) then
+         if (allocated(array)) deallocate(array)
+         allocate(array(size(rec%array3, dim = 1), size(rec%array3, dim = 2), size(rec%array3, dim=3)))
+         array = rec%array3
+      else
+         return
+      end if
+   end associate
 
-end subroutine 
- 
+end subroutine
+
 subroutine push(self, label, it)
-    class(double_dictionary_type), intent(inout) :: self
-    character(len=*), intent(in) :: label
- 
-    integer, intent(out) :: it
- 
-    if (.not.allocated(self%record)) call resize(self%record)
-    it = find(self%record(:self%n), label)
- 
-    if (it == 0) then
-       if (self%n >= size(self%record)) then
-          call resize(self%record)
-       end if
- 
-       self%n = self%n + 1
-       it = self%n
-       self%record(it) = double_record(label)
-    end if
- end subroutine push
- 
-subroutine ini_label(self,label)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    integer :: it
+   class(double_dictionary_type), intent(inout) :: self
+   character(len=*), intent(in) :: label
 
-    call self%push(label, it)
+   integer, intent(out) :: it
+
+   if (.not.allocated(self%record)) call resize(self%record)
+   it = find(self%record(:self%n), label)
+
+   if (it == 0) then
+      if (self%n >= size(self%record)) then
+         call resize(self%record)
+      end if
+
+      self%n = self%n + 1
+      it = self%n
+      self%record(it) = double_record(label)
+   end if
+end subroutine push
+
+subroutine ini_label(self,label)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   integer :: it
+
+   call self%push(label, it)
 end subroutine
 
 subroutine ini_1d(self, label, ndim1)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    integer :: ndim1
-    integer :: it
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   integer :: ndim1
+   integer :: it
 
-    call self%push(label, it)
+   call self%push(label, it)
 
-    associate(record => self%record(it))
-        allocate(record%array1(ndim1), source = 0.0_wp)
-     end associate
+   associate(record => self%record(it))
+      allocate(record%array1(ndim1), source = 0.0_wp)
+   end associate
 end subroutine
 
 subroutine ini_2d(self, label, ndim1, ndim2)
-    
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    integer :: ndim1, ndim2
 
-    integer :: it
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   integer :: ndim1, ndim2
 
-    call self%push(label, it)
+   integer :: it
 
-    associate(record => self%record(it))
-        allocate(record%array2(ndim1, ndim2), source = 0.0_wp)
-     end associate
+   call self%push(label, it)
+
+   associate(record => self%record(it))
+      allocate(record%array2(ndim1, ndim2), source = 0.0_wp)
+   end associate
 end subroutine
 
 subroutine ini_3d(self, label, ndim1, ndim2, ndim3)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    integer :: ndim1, ndim2, ndim3
-    integer :: it
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   integer :: ndim1, ndim2, ndim3
+   integer :: it
 
-    call self%push(label, it)
+   call self%push(label, it)
 
-    associate(record => self%record(it))
-        allocate(record%array3(ndim1, ndim2, ndim3), source = 0.0_wp)
-     end associate
+   associate(record => self%record(it))
+      allocate(record%array3(ndim1, ndim2, ndim3), source = 0.0_wp)
+   end associate
 end subroutine
 
-subroutine add_1d(self, label, array)    
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:) 
-    integer :: it 
+subroutine add_1d(self, label, array)
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:)
+   integer :: it
 
-    call self%push(label, it)
+   call self%push(label, it)
 
-    associate(record => self%record(it))
-        call move_alloc(array, record%array1)
-    end associate
+   associate(record => self%record(it))
+      call move_alloc(array, record%array1)
+   end associate
 end subroutine
 
 subroutine add_2d(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:,:) 
-    integer :: it 
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:,:)
+   integer :: it
 
-    call self%push(label, it)
+   call self%push(label, it)
 
-    associate(record => self%record(it))
-        call move_alloc(array, record%array2)
-    end associate
+   associate(record => self%record(it))
+      call move_alloc(array, record%array2)
+   end associate
 
 end subroutine
 
 subroutine add_3d(self, label, array)
-    class(double_dictionary_type) :: self
-    character(len=*) :: label
-    real(wp), allocatable :: array(:, :, :) 
-    integer :: it 
+   class(double_dictionary_type) :: self
+   character(len=*) :: label
+   real(wp), allocatable :: array(:, :, :)
+   integer :: it
 
-    call self%push(label, it)
+   call self%push(label, it)
 
-    associate(record => self%record(it))
-        call move_alloc(array, record%array3)
-    end associate
-end subroutine 
-  
- 
+   associate(record => self%record(it))
+      call move_alloc(array, record%array3)
+   end associate
+end subroutine
+
+
 function return_label_index(self, label) result(it)
-    class(double_dictionary_type), intent(in) :: self
-    character(len=*), intent(in) :: label
- 
-    integer :: it
- 
-    if (self%n <= 0) return
-    it = find(self%record(:self%n), label)
-    if (it == 0) return
- 
+   class(double_dictionary_type), intent(in) :: self
+   character(len=*), intent(in) :: label
+
+   integer :: it
+
+   if (self%n <= 0) return
+   it = find(self%record(:self%n), label)
+   if (it == 0) return
+
 end function return_label_index
- 
- 
+
+
 pure function find(record, label) result(pos)
-    type(double_record), intent(in) :: record(:)
-    character(len=*), intent(in) :: label
-    integer :: pos
- 
-    integer :: i
- 
-    pos = 0
-    
-    do i = size(record), 1, -1
-        if (allocated(record(i)%label)) then
-            if (label == record(i)%label) then
-                pos = i
-                exit
-            end if
-        end if
-    end do
-    
- end function find 
- 
- !> Reallocate list of double arrays
- pure subroutine resize(var, n)
-    !> Instance of the array to be resized
-    type(double_record), allocatable, intent(inout) :: var(:)
-    !> Dimension of the final array size
-    integer, intent(in), optional :: n
- 
-    type(double_record), allocatable :: tmp(:)
-    integer :: this_size, new_size
-    integer, parameter :: initial_size = 20
- 
-    if (allocated(var)) then
-       this_size = size(var, 1)
-       call move_alloc(var, tmp)
-    else
-       this_size = initial_size
-    end if
- 
-    if (present(n)) then
-       new_size = n
-    else
-       new_size = this_size + this_size/2 + 1
-    end if
- 
-    allocate(var(new_size))
- 
-    if (allocated(tmp)) then
-       this_size = min(size(tmp, 1), size(var, 1))
-       var(:this_size) = tmp(:this_size)
-       deallocate(tmp)
-    end if
- 
- end subroutine resize
- 
- end module tblite_double_dictionary
+   type(double_record), intent(in) :: record(:)
+   character(len=*), intent(in) :: label
+   integer :: pos
+
+   integer :: i
+
+   pos = 0
+
+   do i = size(record), 1, -1
+      if (allocated(record(i)%label)) then
+         if (label == record(i)%label) then
+            pos = i
+            exit
+         end if
+      end if
+   end do
+
+end function find
+
+   !> Reallocate list of double arrays
+pure subroutine resize(var, n)
+   !> Instance of the array to be resized
+   type(double_record), allocatable, intent(inout) :: var(:)
+   !> Dimension of the final array size
+   integer, intent(in), optional :: n
+
+   type(double_record), allocatable :: tmp(:)
+   integer :: this_size, new_size
+   integer, parameter :: initial_size = 20
+
+   if (allocated(var)) then
+      this_size = size(var, 1)
+      call move_alloc(var, tmp)
+   else
+      this_size = initial_size
+   end if
+
+   if (present(n)) then
+      new_size = n
+   else
+      new_size = this_size + this_size/2 + 1
+   end if
+
+   allocate(var(new_size))
+
+   if (allocated(tmp)) then
+      this_size = min(size(tmp, 1), size(var, 1))
+      var(:this_size) = tmp(:this_size)
+      deallocate(tmp)
+   end if
+
+end subroutine resize
+
+end module tblite_double_dictionary

--- a/src/tblite/dictionary.f90
+++ b/src/tblite/dictionary.f90
@@ -121,7 +121,6 @@ subroutine copy_record(to, from)
    if (allocated(from%array1)) to%array1 = from%array1
    if (allocated(from%array2)) to%array2 = from%array2
    if (allocated(from%array3)) to%array3 = from%array3
-
 end subroutine
 
 subroutine concatenate_overwrite(self, dict2)
@@ -383,26 +382,26 @@ end subroutine
 subroutine add_1d(self, label, array)
    class(double_dictionary_type) :: self
    character(len=*) :: label
-   real(wp), allocatable :: array(:)
+   real(wp) :: array(:)
    integer :: it
 
    call self%push(label, it)
 
    associate(record => self%record(it))
-      call move_alloc(array, record%array1)
+      record%array1 = array
    end associate
 end subroutine
 
 subroutine add_2d(self, label, array)
    class(double_dictionary_type) :: self
    character(len=*) :: label
-   real(wp), allocatable :: array(:,:)
+   real(wp) :: array(:,:)
    integer :: it
 
    call self%push(label, it)
 
    associate(record => self%record(it))
-      call move_alloc(array, record%array2)
+      record%array2 = array
    end associate
 
 end subroutine
@@ -410,13 +409,13 @@ end subroutine
 subroutine add_3d(self, label, array)
    class(double_dictionary_type) :: self
    character(len=*) :: label
-   real(wp), allocatable :: array(:, :, :)
+   real(wp) :: array(:, :, :)
    integer :: it
 
    call self%push(label, it)
 
    associate(record => self%record(it))
-      call move_alloc(array, record%array3)
+      record%array3 = array
    end associate
 end subroutine
 

--- a/src/tblite/double_dictionary.f90
+++ b/src/tblite/double_dictionary.f90
@@ -1,3 +1,24 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> @dir tblite/double_dictionary
+!> Contains implemenation of a dictionary with strings as keys and arrays of doubles as entries.
+
+!> @file tblite/double_dictionery.f90
+!> Implements double dictionary type
 module tblite_double_dictionary
    use mctc_env_accuracy, only : wp, i8
    implicit none

--- a/src/tblite/meson.build
+++ b/src/tblite/meson.build
@@ -49,6 +49,7 @@ srcs += files(
   'coulomb.f90',
   'cutoff.f90',
   'data.f90',
+  'dictionary.f90',
   'disp.f90',
   'lapack.f90',
   'ncoord.f90',

--- a/src/tblite/meson.build
+++ b/src/tblite/meson.build
@@ -49,7 +49,7 @@ srcs += files(
   'coulomb.f90',
   'cutoff.f90',
   'data.f90',
-  'dictionary.f90',
+  'double_dictionary.f90',
   'disp.f90',
   'lapack.f90',
   'ncoord.f90',

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
   "cgto-ortho"
   "coulomb-charge"
   "coulomb-multipole"
+  "double-dictionary"
   "fit"
   "gfn1-xtb"
   "gfn2-xtb"

--- a/test/unit/main.f90
+++ b/test/unit/main.f90
@@ -41,6 +41,7 @@ program tester
    use test_tagged_io, only : collect_tagged_io
    use test_xtb_external, only : collect_xtb_external
    use test_xtb_param, only : collect_xtb_param
+   use test_double_dictionary, only : collect_double_dictionary
    implicit none
    integer :: stat, is
    character(len=:), allocatable :: suite_name, test_name
@@ -59,6 +60,7 @@ program tester
       new_testsuite("solvation-surface", collect_solvation_surface), &
       new_testsuite("coulomb-charge", collect_coulomb_charge), &
       new_testsuite("coulomb-multipole", collect_coulomb_multipole), &
+      new_testsuite("double-dictionary", collect_double_dictionary), &
       new_testsuite("slater-expansion", collect_slater_expansion), &
       new_testsuite("cgto-ortho", collect_cgto_ortho), &
       new_testsuite("integral-overlap", collect_integral_overlap), &

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -33,6 +33,7 @@ tests = [
   'cgto-ortho',
   'coulomb-charge',
   'coulomb-multipole',
+  'double-dictionary',
   'fit',
   'gfn1-xtb',
   'gfn2-xtb',

--- a/test/unit/test_double_dictionary.f90
+++ b/test/unit/test_double_dictionary.f90
@@ -1,0 +1,345 @@
+module test_double_dictionary
+    use mctc_env, only : wp
+    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check, &
+      & test_failed
+    use tblite_double_dictionary, only : double_dictionary_type
+    implicit none
+    private
+
+    public :: collect_double_dictionary
+
+contains 
+
+subroutine collect_double_dictionary(testsuite)
+
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+    testsuite = [ &
+        new_unittest("add entries", test_add_entries), &
+        new_unittest("get entries by label", test_get_entries_by_label), &
+        new_unittest("get entries by index", test_get_entries_by_index), &
+        new_unittest("get label from index", test_get_label_from_index), &
+        new_unittest("test = assigment operator", test_assigment_operator), &
+        new_unittest("test + operator", test_addition_operator), & 
+        new_unittest("access entries with invalid label or index", test_invalid_label_index), &
+        new_unittest("access valid entries with wrong size of array as return", test_invalid_array_size), &
+        new_unittest("compare index and label lookup", test_equivalence_index_label_lookup), &
+        new_unittest("initialize labels", test_initialize_labels) &
+    ]
+end subroutine collect_double_dictionary
+
+subroutine test_initialize_labels(error)
+
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+    
+    call dict%initialize_entry("test")
+
+    call dict%initialize_entry("test1", 4)
+
+    call dict%initialize_entry("test2", 4, 6)
+
+    call dict%initialize_entry("test3", 4, 6, 9)    
+
+    call check(error, size(dict%record), 4)
+    !Checking records directly since lookup will be tested in another test
+    call check(error, (.not.(allocated(dict%record(1)%array1))))
+    call check(error, (.not.(allocated(dict%record(1)%array2))))
+    call check(error, (.not.(allocated(dict%record(1)%array3))))
+
+    call check(error, actual = size(dict%record(2)%array1), expected = 4)
+    call check(error, actual = sum(dict%record(2)%array1), expected = 0.0_wp)
+
+    call check(error, actual = size(dict%record(3)%array2, dim = 1), expected = 4)
+    call check(error, actual = size(dict%record(3)%array2, dim = 2), expected = 6)
+    call check(error, actual = sum(dict%record(3)%array2), expected = 0.0_wp)
+
+    call check(error, actual = size(dict%record(4)%array3, dim = 1), expected = 4)
+    call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 6)
+    call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 9)
+    call check(error, actual = sum(dict%record(4)%array3), expected = 0.0_wp)
+
+end subroutine    
+
+subroutine test_add_entries(error)
+
+    type(error_type), allocatable, intent(out) :: error
+    type(double_dictionary_type) :: dict
+
+    call fill_test_dict(dict)
+
+    call check(error, size(dict%record), 3)
+    call check(error, actual = size(dict%record(1)%array1), expected = 4)
+    call check(error, actual = sum(dict%record(1)%array1), expected = 4.0_wp)
+
+    call check(error, actual = size(dict%record(2)%array2, dim = 1), expected = 4)
+    call check(error, actual = size(dict%record(2)%array2, dim = 2), expected = 6)
+    call check(error, actual = sum(dict%record(2)%array2), expected = (4*6*2.0_wp))
+
+    call check(error, actual = size(dict%record(3)%array3, dim = 1), expected = 4)
+    call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 6)
+    call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 9)
+    call check(error, actual = sum(dict%record(3)%array3), expected = 0.0_wp)
+
+end subroutine
+
+subroutine test_get_entries_by_label(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+
+    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+
+    allocate(array1(4), source = 1.0_wp)
+    allocate(array2(4, 6), source = 2.0_wp)
+    allocate(array3(4, 6, 9), source = 0.0_wp)
+
+    array1_in = array1
+    array2_in = array2
+    array3_in = array3
+
+    call dict%add_entry("test1", array1)
+
+    call dict%add_entry("test2", array2)
+
+    call dict%add_entry("test3", array3)
+
+    call dict%get_entry("test1", array1)
+    call dict%get_entry("test2", array2)
+    call dict%get_entry("test3", array3)
+
+    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+
+end subroutine
+
+subroutine test_get_entries_by_index(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+
+    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+
+    allocate(array1(4), source = 1.0_wp)
+    allocate(array2(4, 6), source = 2.0_wp)
+    allocate(array3(4, 6, 9), source = 0.0_wp)
+
+    array1_in = array1
+    array2_in = array2
+    array3_in = array3
+
+    call dict%add_entry("test1", array1)
+
+    call dict%add_entry("test2", array2)
+
+    call dict%add_entry("test3", array3)
+
+    call dict%get_entry(1, array1)
+    call dict%get_entry(2, array2)
+    call dict%get_entry(3, array3)
+
+    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+
+end subroutine
+
+subroutine test_equivalence_index_label_lookup(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+
+    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+
+    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+
+    call fill_test_dict(dict)
+
+    call dict%get_entry("test1", array1)
+    call dict%get_entry("test2", array2)
+    call dict%get_entry("test3", array3)
+
+    call dict%get_entry(1, array1_in)
+    call dict%get_entry(2, array2_in)
+    call dict%get_entry(3, array3_in)
+
+    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+
+end subroutine
+
+subroutine test_invalid_label_index(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+    real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
+    
+    call fill_test_dict(dict)
+
+    call dict%get_entry("label4", array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(4, array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(0, array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(-1, array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry("label4", array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry(4, array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry(0, array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry(-1, array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry("label4", array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry(4, array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry(0, array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry(-1, array3)
+    call check(error, (.not.allocated(array3)))
+
+end subroutine
+
+subroutine test_invalid_array_size(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    type(double_dictionary_type) :: dict
+    real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
+    
+    call fill_test_dict(dict)
+
+    call dict%get_entry("test1", array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry(1, array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry(1, array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry("test1", array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry("test2", array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(2, array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(2, array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry("test2", array3)
+    call check(error, (.not.allocated(array3)))
+
+    call dict%get_entry("test3", array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(3, array)
+    call check(error, (.not.allocated(array)))
+
+    call dict%get_entry(3, array2)
+    call check(error, (.not.allocated(array2)))
+
+    call dict%get_entry("test3", array2)
+    call check(error, (.not.allocated(array2)))
+
+end subroutine
+
+subroutine test_get_label_from_index(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(double_dictionary_type) :: dict
+    character(len=:), allocatable :: name1
+
+    call fill_test_dict(dict)
+    call dict%get_label(1, name1)
+    call check(error, (name1 == "test1"))    
+    call dict%get_label(2, name1)
+    call check(error, (name1 == "test2"))
+    call dict%get_label(3, name1)
+    call check(error, (name1 == "test3"))
+end subroutine    
+
+subroutine fill_test_dict(dict)
+    type(double_dictionary_type), intent(inout) :: dict
+    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+    allocate(array1(4), source = 1.0_wp)
+    allocate(array2(4, 6), source = 2.0_wp)
+    allocate(array3(4, 6, 9), source = 0.0_wp)
+
+    call dict%add_entry("test1", array1)
+
+    call dict%add_entry("test2", array2)
+
+    call dict%add_entry("test3", array3)
+end subroutine
+
+subroutine test_assigment_operator(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(double_dictionary_type) :: dict1, dict2
+    call fill_test_dict(dict1)
+
+    dict2 = dict1
+
+    call check(error, dict1%n , dict2%n)
+    
+    call check(error, sum(dict1%record(1)%array1 - dict2%record(1)%array1), 0.0_wp)
+
+    call check(error, sum(dict1%record(2)%array2 - dict2%record(2)%array2), 0.0_wp)
+
+    call check(error, sum(dict1%record(3)%array3 - dict2%record(3)%array3), 0.0_wp)
+
+end subroutine
+
+subroutine test_addition_operator(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(double_dictionary_type) :: dict1, dict2, dict3 
+    character(len=:), allocatable :: label1, label2
+    real(wp), allocatable :: array(:), array1(:), array2(:)
+    call fill_test_dict(dict1)
+    array = [0.0_wp, 0.0_wp]
+    call dict2%add_entry("dict2", array)
+    call dict2%add_entry("dict3", array) 
+
+    dict3 = dict1 + dict2
+    !Check that total number of entries matches up
+    call check(error, actual = dict3%get_n_entries(), expected = (dict1%get_n_entries()+ dict2%get_n_entries()))
+    !Check Ordering LHS should vom before RHS
+    call dict3%get_label(2, label1)
+    call dict1%get_label(2, label2)
+    call check(error, (label1 == label2))
+
+    call dict3%get_label(5, label1)
+    call dict2%get_label(2, label2)
+    call check(error, (label1 == label2))
+
+    call dict3%get_entry(1, array1)
+    call dict1%get_entry(1, array2)
+    call check(error, (sum(array1) == sum(array2)))
+
+    call dict3%get_entry("dict3", array1)
+    call dict2%get_entry(2, array2)
+    call check(error, (sum(array1) == sum(array2)))
+
+end subroutine
+
+end module test_double_dictionary

--- a/test/unit/test_double_dictionary.f90
+++ b/test/unit/test_double_dictionary.f90
@@ -1,344 +1,344 @@
 module test_double_dictionary
-    use mctc_env, only : wp
-    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check, &
+   use mctc_env, only : wp
+   use mctc_env_testing, only : new_unittest, unittest_type, error_type, check, &
       & test_failed
-    use tblite_double_dictionary, only : double_dictionary_type
-    implicit none
-    private
+   use tblite_double_dictionary, only : double_dictionary_type
+   implicit none
+   private
 
-    public :: collect_double_dictionary
+   public :: collect_double_dictionary
 
-contains 
+contains
 
 subroutine collect_double_dictionary(testsuite)
 
-    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
-    testsuite = [ &
-        new_unittest("add entries", test_add_entries), &
-        new_unittest("get entries by label", test_get_entries_by_label), &
-        new_unittest("get entries by index", test_get_entries_by_index), &
-        new_unittest("get label from index", test_get_label_from_index), &
-        new_unittest("test = assigment operator", test_assigment_operator), &
-        new_unittest("test + operator", test_addition_operator), & 
-        new_unittest("access entries with invalid label or index", test_invalid_label_index), &
-        new_unittest("access valid entries with wrong size of array as return", test_invalid_array_size), &
-        new_unittest("compare index and label lookup", test_equivalence_index_label_lookup), &
-        new_unittest("initialize labels", test_initialize_labels) &
-    ]
+   testsuite = [ &
+      new_unittest("add entries", test_add_entries), &
+      new_unittest("get entries by label", test_get_entries_by_label), &
+      new_unittest("get entries by index", test_get_entries_by_index), &
+      new_unittest("get label from index", test_get_label_from_index), &
+      new_unittest("test = assigment operator", test_assigment_operator), &
+      new_unittest("test + operator", test_addition_operator), &
+      new_unittest("access entries with invalid label or index", test_invalid_label_index), &
+      new_unittest("access valid entries with wrong size of array as return", test_invalid_array_size), &
+      new_unittest("compare index and label lookup", test_equivalence_index_label_lookup), &
+      new_unittest("initialize labels", test_initialize_labels) &
+      ]
 end subroutine collect_double_dictionary
 
 subroutine test_initialize_labels(error)
 
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
-    
-    call dict%initialize_entry("test")
+   type(double_dictionary_type) :: dict
 
-    call dict%initialize_entry("test1", 4)
+   call dict%initialize_entry("test")
 
-    call dict%initialize_entry("test2", 4, 6)
+   call dict%initialize_entry("test1", 4)
 
-    call dict%initialize_entry("test3", 4, 6, 9)    
+   call dict%initialize_entry("test2", 4, 6)
 
-    call check(error, size(dict%record), 4)
-    !Checking records directly since lookup will be tested in another test
-    call check(error, (.not.(allocated(dict%record(1)%array1))))
-    call check(error, (.not.(allocated(dict%record(1)%array2))))
-    call check(error, (.not.(allocated(dict%record(1)%array3))))
+   call dict%initialize_entry("test3", 4, 6, 9)
 
-    call check(error, actual = size(dict%record(2)%array1), expected = 4)
-    call check(error, actual = sum(dict%record(2)%array1), expected = 0.0_wp)
+   call check(error, size(dict%record), 4)
+   !Checking records directly since lookup will be tested in another test
+   call check(error, (.not.(allocated(dict%record(1)%array1))))
+   call check(error, (.not.(allocated(dict%record(1)%array2))))
+   call check(error, (.not.(allocated(dict%record(1)%array3))))
 
-    call check(error, actual = size(dict%record(3)%array2, dim = 1), expected = 4)
-    call check(error, actual = size(dict%record(3)%array2, dim = 2), expected = 6)
-    call check(error, actual = sum(dict%record(3)%array2), expected = 0.0_wp)
+   call check(error, actual = size(dict%record(2)%array1), expected = 4)
+   call check(error, actual = sum(dict%record(2)%array1), expected = 0.0_wp)
 
-    call check(error, actual = size(dict%record(4)%array3, dim = 1), expected = 4)
-    call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 6)
-    call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 9)
-    call check(error, actual = sum(dict%record(4)%array3), expected = 0.0_wp)
+   call check(error, actual = size(dict%record(3)%array2, dim = 1), expected = 4)
+   call check(error, actual = size(dict%record(3)%array2, dim = 2), expected = 6)
+   call check(error, actual = sum(dict%record(3)%array2), expected = 0.0_wp)
 
-end subroutine    
+   call check(error, actual = size(dict%record(4)%array3, dim = 1), expected = 4)
+   call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 6)
+   call check(error, actual = size(dict%record(4)%array3, dim = 2), expected = 9)
+   call check(error, actual = sum(dict%record(4)%array3), expected = 0.0_wp)
+
+end subroutine
 
 subroutine test_add_entries(error)
 
-    type(error_type), allocatable, intent(out) :: error
-    type(double_dictionary_type) :: dict
+   type(error_type), allocatable, intent(out) :: error
+   type(double_dictionary_type) :: dict
 
-    call fill_test_dict(dict)
+   call fill_test_dict(dict)
 
-    call check(error, size(dict%record), 3)
-    call check(error, actual = size(dict%record(1)%array1), expected = 4)
-    call check(error, actual = sum(dict%record(1)%array1), expected = 4.0_wp)
+   call check(error, size(dict%record), 3)
+   call check(error, actual = size(dict%record(1)%array1), expected = 4)
+   call check(error, actual = sum(dict%record(1)%array1), expected = 4.0_wp)
 
-    call check(error, actual = size(dict%record(2)%array2, dim = 1), expected = 4)
-    call check(error, actual = size(dict%record(2)%array2, dim = 2), expected = 6)
-    call check(error, actual = sum(dict%record(2)%array2), expected = (4*6*2.0_wp))
+   call check(error, actual = size(dict%record(2)%array2, dim = 1), expected = 4)
+   call check(error, actual = size(dict%record(2)%array2, dim = 2), expected = 6)
+   call check(error, actual = sum(dict%record(2)%array2), expected = (4*6*2.0_wp))
 
-    call check(error, actual = size(dict%record(3)%array3, dim = 1), expected = 4)
-    call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 6)
-    call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 9)
-    call check(error, actual = sum(dict%record(3)%array3), expected = 0.0_wp)
+   call check(error, actual = size(dict%record(3)%array3, dim = 1), expected = 4)
+   call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 6)
+   call check(error, actual = size(dict%record(3)%array3, dim = 2), expected = 9)
+   call check(error, actual = sum(dict%record(3)%array3), expected = 0.0_wp)
 
 end subroutine
 
 subroutine test_get_entries_by_label(error)
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
+   type(double_dictionary_type) :: dict
 
-    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
-    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+   real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+   real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
 
-    allocate(array1(4), source = 1.0_wp)
-    allocate(array2(4, 6), source = 2.0_wp)
-    allocate(array3(4, 6, 9), source = 0.0_wp)
+   allocate(array1(4), source = 1.0_wp)
+   allocate(array2(4, 6), source = 2.0_wp)
+   allocate(array3(4, 6, 9), source = 0.0_wp)
 
-    array1_in = array1
-    array2_in = array2
-    array3_in = array3
+   array1_in = array1
+   array2_in = array2
+   array3_in = array3
 
-    call dict%add_entry("test1", array1)
+   call dict%add_entry("test1", array1)
 
-    call dict%add_entry("test2", array2)
+   call dict%add_entry("test2", array2)
 
-    call dict%add_entry("test3", array3)
+   call dict%add_entry("test3", array3)
 
-    call dict%get_entry("test1", array1)
-    call dict%get_entry("test2", array2)
-    call dict%get_entry("test3", array3)
+   call dict%get_entry("test1", array1)
+   call dict%get_entry("test2", array2)
+   call dict%get_entry("test3", array3)
 
-    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
-    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
-    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+   call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+   call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+   call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
 
 end subroutine
 
 subroutine test_get_entries_by_index(error)
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
+   type(double_dictionary_type) :: dict
 
-    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
-    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+   real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+   real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
 
-    allocate(array1(4), source = 1.0_wp)
-    allocate(array2(4, 6), source = 2.0_wp)
-    allocate(array3(4, 6, 9), source = 0.0_wp)
+   allocate(array1(4), source = 1.0_wp)
+   allocate(array2(4, 6), source = 2.0_wp)
+   allocate(array3(4, 6, 9), source = 0.0_wp)
 
-    array1_in = array1
-    array2_in = array2
-    array3_in = array3
+   array1_in = array1
+   array2_in = array2
+   array3_in = array3
 
-    call dict%add_entry("test1", array1)
+   call dict%add_entry("test1", array1)
 
-    call dict%add_entry("test2", array2)
+   call dict%add_entry("test2", array2)
 
-    call dict%add_entry("test3", array3)
+   call dict%add_entry("test3", array3)
 
-    call dict%get_entry(1, array1)
-    call dict%get_entry(2, array2)
-    call dict%get_entry(3, array3)
+   call dict%get_entry(1, array1)
+   call dict%get_entry(2, array2)
+   call dict%get_entry(3, array3)
 
-    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
-    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
-    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+   call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+   call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+   call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
 
 end subroutine
 
 subroutine test_equivalence_index_label_lookup(error)
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
+   type(double_dictionary_type) :: dict
 
-    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+   real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
 
-    real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
+   real(wp), allocatable :: array1_in(:), array2_in(:, :), array3_in(:, :, :)
 
-    call fill_test_dict(dict)
+   call fill_test_dict(dict)
 
-    call dict%get_entry("test1", array1)
-    call dict%get_entry("test2", array2)
-    call dict%get_entry("test3", array3)
+   call dict%get_entry("test1", array1)
+   call dict%get_entry("test2", array2)
+   call dict%get_entry("test3", array3)
 
-    call dict%get_entry(1, array1_in)
-    call dict%get_entry(2, array2_in)
-    call dict%get_entry(3, array3_in)
+   call dict%get_entry(1, array1_in)
+   call dict%get_entry(2, array2_in)
+   call dict%get_entry(3, array3_in)
 
-    call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
-    call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
-    call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
+   call check(error, actual = sum(array1 - array1_in), expected = 0.0_wp)
+   call check(error, actual = sum(array2 - array2_in), expected = 0.0_wp)
+   call check(error, actual = sum(array3 - array3_in), expected = 0.0_wp)
 
 end subroutine
 
 subroutine test_invalid_label_index(error)
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
-    real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
-    
-    call fill_test_dict(dict)
+   type(double_dictionary_type) :: dict
+   real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
 
-    call dict%get_entry("label4", array)
-    call check(error, (.not.allocated(array)))
+   call fill_test_dict(dict)
 
-    call dict%get_entry(4, array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry("label4", array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry(0, array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry(4, array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry(-1, array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry(0, array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry("label4", array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry(-1, array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry(4, array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry("label4", array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry(0, array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry(4, array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry(-1, array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry(0, array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry("label4", array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(-1, array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry(4, array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry("label4", array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry(0, array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(4, array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry(-1, array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(0, array3)
+   call check(error, (.not.allocated(array3)))
+
+   call dict%get_entry(-1, array3)
+   call check(error, (.not.allocated(array3)))
 
 end subroutine
 
 subroutine test_invalid_array_size(error)
-    type(error_type), allocatable, intent(out) :: error
+   type(error_type), allocatable, intent(out) :: error
 
-    type(double_dictionary_type) :: dict
-    real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
-    
-    call fill_test_dict(dict)
+   type(double_dictionary_type) :: dict
+   real(wp), allocatable :: array(:), array2(:, :), array3(:, :, :)
 
-    call dict%get_entry("test1", array2)
-    call check(error, (.not.allocated(array2)))
+   call fill_test_dict(dict)
 
-    call dict%get_entry(1, array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry("test1", array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry(1, array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(1, array2)
+   call check(error, (.not.allocated(array2)))
 
-    call dict%get_entry("test1", array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(1, array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry("test2", array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry("test1", array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry(2, array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry("test2", array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry(2, array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(2, array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry("test2", array3)
-    call check(error, (.not.allocated(array3)))
+   call dict%get_entry(2, array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry("test3", array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry("test2", array3)
+   call check(error, (.not.allocated(array3)))
 
-    call dict%get_entry(3, array)
-    call check(error, (.not.allocated(array)))
+   call dict%get_entry("test3", array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry(3, array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry(3, array)
+   call check(error, (.not.allocated(array)))
 
-    call dict%get_entry("test3", array2)
-    call check(error, (.not.allocated(array2)))
+   call dict%get_entry(3, array2)
+   call check(error, (.not.allocated(array2)))
+
+   call dict%get_entry("test3", array2)
+   call check(error, (.not.allocated(array2)))
 
 end subroutine
 
 subroutine test_get_label_from_index(error)
-    type(error_type), allocatable, intent(out) :: error
-    type(double_dictionary_type) :: dict
-    character(len=:), allocatable :: name1
+   type(error_type), allocatable, intent(out) :: error
+   type(double_dictionary_type) :: dict
+   character(len=:), allocatable :: name1
 
-    call fill_test_dict(dict)
-    call dict%get_label(1, name1)
-    call check(error, (name1 == "test1"))    
-    call dict%get_label(2, name1)
-    call check(error, (name1 == "test2"))
-    call dict%get_label(3, name1)
-    call check(error, (name1 == "test3"))
-end subroutine    
+   call fill_test_dict(dict)
+   call dict%get_label(1, name1)
+   call check(error, (name1 == "test1"))
+   call dict%get_label(2, name1)
+   call check(error, (name1 == "test2"))
+   call dict%get_label(3, name1)
+   call check(error, (name1 == "test3"))
+end subroutine
 
 subroutine fill_test_dict(dict)
-    type(double_dictionary_type), intent(inout) :: dict
-    real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
-    allocate(array1(4), source = 1.0_wp)
-    allocate(array2(4, 6), source = 2.0_wp)
-    allocate(array3(4, 6, 9), source = 0.0_wp)
+   type(double_dictionary_type), intent(inout) :: dict
+   real(wp), allocatable :: array1(:), array2(:, :), array3(:, :, :)
+   allocate(array1(4), source = 1.0_wp)
+   allocate(array2(4, 6), source = 2.0_wp)
+   allocate(array3(4, 6, 9), source = 0.0_wp)
 
-    call dict%add_entry("test1", array1)
+   call dict%add_entry("test1", array1)
 
-    call dict%add_entry("test2", array2)
+   call dict%add_entry("test2", array2)
 
-    call dict%add_entry("test3", array3)
+   call dict%add_entry("test3", array3)
 end subroutine
 
 subroutine test_assigment_operator(error)
-    type(error_type), allocatable, intent(out) :: error
-    type(double_dictionary_type) :: dict1, dict2
-    call fill_test_dict(dict1)
+   type(error_type), allocatable, intent(out) :: error
+   type(double_dictionary_type) :: dict1, dict2
+   call fill_test_dict(dict1)
 
-    dict2 = dict1
+   dict2 = dict1
 
-    call check(error, dict1%n , dict2%n)
-    
-    call check(error, sum(dict1%record(1)%array1 - dict2%record(1)%array1), 0.0_wp)
+   call check(error, dict1%n , dict2%n)
 
-    call check(error, sum(dict1%record(2)%array2 - dict2%record(2)%array2), 0.0_wp)
+   call check(error, sum(dict1%record(1)%array1 - dict2%record(1)%array1), 0.0_wp)
 
-    call check(error, sum(dict1%record(3)%array3 - dict2%record(3)%array3), 0.0_wp)
+   call check(error, sum(dict1%record(2)%array2 - dict2%record(2)%array2), 0.0_wp)
+
+   call check(error, sum(dict1%record(3)%array3 - dict2%record(3)%array3), 0.0_wp)
 
 end subroutine
 
 subroutine test_addition_operator(error)
-    type(error_type), allocatable, intent(out) :: error
-    type(double_dictionary_type) :: dict1, dict2, dict3 
-    character(len=:), allocatable :: label1, label2
-    real(wp), allocatable :: array(:), array1(:), array2(:)
-    call fill_test_dict(dict1)
-    array = [0.0_wp, 0.0_wp]
-    call dict2%add_entry("dict2", array)
-    call dict2%add_entry("dict3", array) 
+   type(error_type), allocatable, intent(out) :: error
+   type(double_dictionary_type) :: dict1, dict2, dict3
+   character(len=:), allocatable :: label1, label2
+   real(wp), allocatable :: array(:), array1(:), array2(:)
+   call fill_test_dict(dict1)
+   array = [0.0_wp, 0.0_wp]
+   call dict2%add_entry("dict2", array)
+   call dict2%add_entry("dict3", array)
 
-    dict3 = dict1 + dict2
-    !Check that total number of entries matches up
-    call check(error, actual = dict3%get_n_entries(), expected = (dict1%get_n_entries()+ dict2%get_n_entries()))
-    !Check Ordering LHS should vom before RHS
-    call dict3%get_label(2, label1)
-    call dict1%get_label(2, label2)
-    call check(error, (label1 == label2))
+   dict3 = dict1 + dict2
+   !Check that total number of entries matches up
+   call check(error, actual = dict3%get_n_entries(), expected = (dict1%get_n_entries()+ dict2%get_n_entries()))
+   !Check Ordering LHS should vom before RHS
+   call dict3%get_label(2, label1)
+   call dict1%get_label(2, label2)
+   call check(error, (label1 == label2))
 
-    call dict3%get_label(5, label1)
-    call dict2%get_label(2, label2)
-    call check(error, (label1 == label2))
+   call dict3%get_label(5, label1)
+   call dict2%get_label(2, label2)
+   call check(error, (label1 == label2))
 
-    call dict3%get_entry(1, array1)
-    call dict1%get_entry(1, array2)
-    call check(error, (sum(array1) == sum(array2)))
+   call dict3%get_entry(1, array1)
+   call dict1%get_entry(1, array2)
+   call check(error, (sum(array1) == sum(array2)))
 
-    call dict3%get_entry("dict3", array1)
-    call dict2%get_entry(2, array2)
-    call check(error, (sum(array1) == sum(array2)))
+   call dict3%get_entry("dict3", array1)
+   call dict2%get_entry(2, array2)
+   call check(error, (sum(array1) == sum(array2)))
 
 end subroutine
 

--- a/test/unit/test_double_dictionary.f90
+++ b/test/unit/test_double_dictionary.f90
@@ -21,12 +21,80 @@ subroutine collect_double_dictionary(testsuite)
       new_unittest("get label from index", test_get_label_from_index), &
       new_unittest("test = assigment operator", test_assigment_operator), &
       new_unittest("test + operator", test_addition_operator), &
+      new_unittest("test remove functionality by index", test_removal_index), &
+      new_unittest("test remove functionality by label", test_removal_label), &
       new_unittest("access entries with invalid label or index", test_invalid_label_index), &
       new_unittest("access valid entries with wrong size of array as return", test_invalid_array_size), &
       new_unittest("compare index and label lookup", test_equivalence_index_label_lookup), &
       new_unittest("initialize labels", test_initialize_labels) &
       ]
 end subroutine collect_double_dictionary
+
+subroutine test_removal_index(error)
+   type(error_type), allocatable, intent(out) :: error
+   character(len=:), allocatable :: label1, label2
+   real(wp), allocatable :: array1(:), array2(:, :)
+
+   type(double_dictionary_type) :: dict, ini_dict
+
+   call fill_test_dict(dict)
+   ini_dict = dict
+   call dict%remove_entry(3)
+   call check(error, dict%get_n_entries(), 2)
+
+   call dict%remove_entry(3)
+   call check(error, dict%get_n_entries(), 2)
+   call dict%get_label(1, label1)
+   call dict%get_label(2,label2)
+
+   call check(error, (label1 == "test1"))
+   call check(error, (label1 == "test2"))
+   call dict%get_entry("test1", array1)
+   call dict%get_entry("test2", array2)
+
+   call check(error, sum(ini_dict%record(1)%array1 - array1), 0.0_wp)
+   call check(error, sum(ini_dict%record(2)%array2 - array2), 0.0_wp)
+
+   call dict%remove_entry(1)
+   call check(error, dict%get_n_entries(), 1)
+
+   call dict%get_entry("test2", array2)
+   call check(error, sum(ini_dict%record(2)%array2 - array2), 0.0_wp) 
+
+end subroutine
+
+subroutine test_removal_label(error)
+   type(error_type), allocatable, intent(out) :: error
+   character(len=:), allocatable :: label1, label2
+   real(wp), allocatable :: array1(:), array2(:, :)
+
+   type(double_dictionary_type) :: dict, ini_dict
+
+   call fill_test_dict(dict)
+   ini_dict = dict
+   call dict%remove_entry("test3")
+   call check(error, dict%get_n_entries(), 2)
+
+   call dict%remove_entry("test3")
+   call check(error, dict%get_n_entries(), 2)
+   call dict%get_label(1, label1)
+   call dict%get_label(2,label2)
+
+   call check(error, (label1 == "test1"))
+   call check(error, (label1 == "test2"))
+   call dict%get_entry("test1", array1)
+   call dict%get_entry("test2", array2)
+
+   call check(error, sum(ini_dict%record(1)%array1 - array1), 0.0_wp)
+   call check(error, sum(ini_dict%record(2)%array2 - array2), 0.0_wp)
+
+   call dict%remove_entry("test1")
+   call check(error, dict%get_n_entries(), 1)
+
+   call dict%get_entry("test2", array2)
+   call check(error, sum(ini_dict%record(2)%array2 - array2), 0.0_wp) 
+
+end subroutine
 
 subroutine test_initialize_labels(error)
 

--- a/test/unit/test_double_dictionary.f90
+++ b/test/unit/test_double_dictionary.f90
@@ -26,7 +26,8 @@ subroutine collect_double_dictionary(testsuite)
       new_unittest("access entries with invalid label or index", test_invalid_label_index), &
       new_unittest("access valid entries with wrong size of array as return", test_invalid_array_size), &
       new_unittest("compare index and label lookup", test_equivalence_index_label_lookup), &
-      new_unittest("initialize labels", test_initialize_labels) &
+      new_unittest("initialize labels", test_initialize_labels), &
+      new_unittest("update entries", test_update_entries_label) &
       ]
 end subroutine collect_double_dictionary
 
@@ -365,7 +366,8 @@ subroutine test_assigment_operator(error)
    type(error_type), allocatable, intent(out) :: error
    type(double_dictionary_type) :: dict1, dict2
    call fill_test_dict(dict1)
-
+   write(*,*) dict1%get_n_entries()
+   write(*,*) size(dict1%record, dim=1)
    dict2 = dict1
 
    call check(error, dict1%n , dict2%n)
@@ -380,7 +382,7 @@ end subroutine
 
 subroutine test_addition_operator(error)
    type(error_type), allocatable, intent(out) :: error
-   type(double_dictionary_type) :: dict1, dict2, dict3
+   type(double_dictionary_type) :: dict1, dict2, dict3, dict4 
    character(len=:), allocatable :: label1, label2
    real(wp), allocatable :: array(:), array1(:), array2(:)
    call fill_test_dict(dict1)
@@ -407,6 +409,75 @@ subroutine test_addition_operator(error)
    call dict3%get_entry("dict3", array1)
    call dict2%get_entry(2, array2)
    call check(error, (sum(array1) == sum(array2)))
+   
+   dict3 = dict4 + dict1
+
+   call check(error, (dict3%get_n_entries() == dict1%get_n_entries()))
+
+   call dict4%concatenate(dict1)
+
+   call check(error, (dict4%get_n_entries() == dict1%get_n_entries()))
+   call dict4%get_entry(1, array1)
+   call dict1%get_entry(1, array2)
+   call check(error, (sum(array1) == sum(array2)))
+end subroutine
+
+
+
+subroutine test_update_entries_label(error)
+   type(error_type), allocatable, intent(out) :: error
+   type(double_dictionary_type) :: dict1, dict2, dict3 
+   character(len=:), allocatable :: label1, label2
+   real(wp), allocatable :: array(:), array1(:), array2(:, :), array3(:, :, :)
+   call fill_test_dict(dict1)
+   allocate(array(1), source= 0.0_wp)
+   call dict1%update("test1", array)
+   call dict1%get_entry("test1", array1)
+
+   call check(error, (sum(array) == sum(array1)))
+
+   call dict1%update("test2", array)
+   call dict1%get_entry("test2", array1)
+
+   call check(error, (sum(array) == sum(array1)))
+
+   call dict1%update("test3", array)
+   call dict1%get_entry("test3", array1)
+
+   call check(error, (sum(array) == sum(array1)))
+
+   allocate(array2(2, 2), source= 0.0_wp)
+
+   call fill_test_dict(dict2)
+
+   call dict2%update("test1", array2)
+   call dict2%update("test2", array2)
+   call dict2%update("test3", array2)
+
+   deallocate(array2)
+
+   call dict2%get_entry("test1", array2)
+   call check(error, (size(array2, dim=1) == 2))
+   call dict2%get_entry("test2", array2)
+   call check(error, (size(array2, dim=1) == 2))
+   call dict2%get_entry("test3", array2)
+   call check(error, (size(array2, dim=1) == 2))
+
+   allocate(array3(3, 2, 1), source= 1.0_wp)
+   call fill_test_dict(dict3)
+
+   call dict3%update("test1", array3)
+   call dict3%update("test2", array3)
+   call dict3%update("test3", array3)
+
+   deallocate(array2)
+
+   call dict3%get_entry("test1", array3)
+   call check(error, (size(array3, dim=1) == 3))
+   call dict3%get_entry("test2", array3)
+   call check(error, (size(array3, dim=1) == 3))
+   call dict3%get_entry("test3", array2)
+   call check(error, (size(array3, dim=1) == 3))
 
 end subroutine
 


### PR DESCRIPTION
I added a dictionary derived type that takes doubles arrays as entries, the size of the array can vary by entry.
The dimension of the array is currently explicitly coded for 3 dimensions, maybe a smarter solution is possible.
A lookup is possible via the label of the entry or its index, returning the array if the appropriate size of array is given otherwise the array stays unallocated same if the label or index is not in the dictionary.
The labels can also be looked up via the index, which allows to print out or pack the content of the dictionary in an easy fashion.

I also added an explicit assignment operator as well as + operator to allow easy concatenation of dictionaries.

The introduction of this class will allow a more efficient collection of various ML feature categories, that will be subject to a future pull request. 
A testsuite for the functionality is also provided.

Thanks in advance
Pit