### PR TITLE
add bind(C) to callback function of context 

### DIFF
--- a/src/tblite/api/context.f90
+++ b/src/tblite/api/context.f90
@@ -42,7 +42,7 @@ module tblite_api_context
 
    abstract interface
       !> Interface for callbacks used in custom logger
-      subroutine callback(msg, len, udata)
+      subroutine callback(msg, len, udata) bind(C)
          import :: c_char, c_int, c_ptr
          !> Message payload to be displayed
          character(len=1, kind=c_char), intent(in) :: msg(*)


### PR DESCRIPTION
I ran into issues, when compiling the project with newer intel compilers. The main issue I encountered was that when running singlepoint calculations from python, I get errors from cffi that the length of the char pointer is returned as negative. Therefore the passed message can not be decoded.

I managed to solve the issue by adding the bind(C) attribute to the callback function. Now everything works fine with intel oneAPI compilers (so far I tested with ifort 2021.10.0, more from our cluster following) as well.