### PR TITLE
Fix OMP memory leak in Coulomb matrix derivatives

### DIFF
--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -541,13 +541,13 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    dadr(:, :, :) = 0.0_wp
    dadL(:, :, :) = 0.0_wp
 
+   itrace = atrace
+   didr = dadr
+   didL = dadL
    !$omp parallel default(none) &
    !$omp shared(atrace, dadr, dadL, mol, qvec, hubbard, nshell, offset, gexp) &
    !$omp private(iat, izp, ii, ish, jat, jzp, jj, jsh, gam, r1, vec, dG, dS, dtmp, arg) &
    !$omp private(itrace, didr, didL)
-   itrace = atrace
-   didr = dadr
-   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)
@@ -625,13 +625,13 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    call get_dir_trans(mol%lattice, alpha, conv, dtrans)
    call get_rec_trans(mol%lattice, alpha, vol, conv, rtrans)
 
+   itrace = atrace
+   didr = dadr
+   didL = dadL
    !$omp parallel default(none) shared(atrace, dadr, dadL) &
    !$omp shared(mol, wsc, alpha, vol, dtrans, rtrans, qvec, hubbard, nshell, offset, gexp, &
    !$omp& rcut) private(iat, izp, jat, jzp, img, ii, jj, ish, jsh, gam, wsw, vec, dG, dS, &
    !$omp& dGr, dSr, dGd, dSd, itrace, didr, didL)
-   itrace = atrace
-   didr = dadr
-   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -548,9 +548,6 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    allocate(itrace, source=atrace)
    allocate(didr, source=dadr)
    allocate(didL, source=dadL)
-   itrace = atrace
-   didr = dadr
-   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)
@@ -636,9 +633,6 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    allocate(itrace, source=atrace)
    allocate(didr, source=dadr)
    allocate(didL, source=dadL)
-   itrace = atrace
-   didr = dadr
-   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -541,13 +541,16 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    dadr(:, :, :) = 0.0_wp
    dadL(:, :, :) = 0.0_wp
 
-   itrace = atrace
-   didr = dadr
-   didL = dadL
+   allocate(itrace, source=atrace)
+   allocate(didr, source=dadr)
+   allocate(didL, source=dadL)
    !$omp parallel default(none) &
    !$omp shared(atrace, dadr, dadL, mol, qvec, hubbard, nshell, offset, gexp) &
    !$omp private(iat, izp, ii, ish, jat, jzp, jj, jsh, gam, r1, vec, dG, dS, dtmp, arg) &
    !$omp private(itrace, didr, didL)
+   itrace = atrace
+   didr = dadr
+   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)
@@ -625,13 +628,16 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    call get_dir_trans(mol%lattice, alpha, conv, dtrans)
    call get_rec_trans(mol%lattice, alpha, vol, conv, rtrans)
 
-   itrace = atrace
-   didr = dadr
-   didL = dadL
+   allocate(itrace, source=atrace)
+   allocate(didr, source=dadr)
+   allocate(didL, source=dadL)
    !$omp parallel default(none) shared(atrace, dadr, dadL) &
    !$omp shared(mol, wsc, alpha, vol, dtrans, rtrans, qvec, hubbard, nshell, offset, gexp, &
    !$omp& rcut) private(iat, izp, jat, jzp, img, ii, jj, ish, jsh, gam, wsw, vec, dG, dS, &
    !$omp& dGr, dSr, dGd, dSd, itrace, didr, didL)
+   itrace = atrace
+   didr = dadr
+   didL = dadL
    !$omp do schedule(runtime)
    do iat = 1, mol%nat
       izp = mol%id(iat)

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -691,7 +691,7 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    dadr(:, :, :) = dadr + didr
    dadL(:, :, :) = dadL + didL
    !$omp end critical (get_damat_3d_)
-   deallocate(didL,didr,itrace) 
+   deallocate(didL, didr, itrace) 
    !$omp end parallel
 
 end subroutine get_damat_3d

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -541,13 +541,13 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    dadr(:, :, :) = 0.0_wp
    dadL(:, :, :) = 0.0_wp
 
-   allocate(itrace, source=atrace)
-   allocate(didr, source=dadr)
-   allocate(didL, source=dadL)
    !$omp parallel default(none) &
    !$omp shared(atrace, dadr, dadL, mol, qvec, hubbard, nshell, offset, gexp) &
    !$omp private(iat, izp, ii, ish, jat, jzp, jj, jsh, gam, r1, vec, dG, dS, dtmp, arg) &
    !$omp private(itrace, didr, didL)
+   allocate(itrace, source=atrace)
+   allocate(didr, source=dadr)
+   allocate(didL, source=dadL)
    itrace = atrace
    didr = dadr
    didL = dadL
@@ -582,6 +582,7 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    dadr(:, :, :) = dadr + didr
    dadL(:, :, :) = dadL + didL
    !$omp end critical (get_damat_0d_)
+   deallocate(didL,didr,itrace)
    !$omp end parallel
 
 end subroutine get_damat_0d
@@ -628,13 +629,13 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    call get_dir_trans(mol%lattice, alpha, conv, dtrans)
    call get_rec_trans(mol%lattice, alpha, vol, conv, rtrans)
 
-   allocate(itrace, source=atrace)
-   allocate(didr, source=dadr)
-   allocate(didL, source=dadL)
    !$omp parallel default(none) shared(atrace, dadr, dadL) &
    !$omp shared(mol, wsc, alpha, vol, dtrans, rtrans, qvec, hubbard, nshell, offset, gexp, &
    !$omp& rcut) private(iat, izp, jat, jzp, img, ii, jj, ish, jsh, gam, wsw, vec, dG, dS, &
    !$omp& dGr, dSr, dGd, dSd, itrace, didr, didL)
+   allocate(itrace, source=atrace)
+   allocate(didr, source=dadr)
+   allocate(didL, source=dadL)
    itrace = atrace
    didr = dadr
    didL = dadL
@@ -690,6 +691,7 @@ subroutine get_damat_3d(mol, nshell, offset, hubbard, gexp, rcut, wsc, alpha, qv
    dadr(:, :, :) = dadr + didr
    dadL(:, :, :) = dadL + didL
    !$omp end critical (get_damat_3d_)
+   deallocate(didL,didr,itrace) 
    !$omp end parallel
 
 end subroutine get_damat_3d

--- a/src/tblite/coulomb/charge/effective.f90
+++ b/src/tblite/coulomb/charge/effective.f90
@@ -582,7 +582,7 @@ subroutine get_damat_0d(mol, nshell, offset, hubbard, gexp, qvec, dadr, dadL, at
    dadr(:, :, :) = dadr + didr
    dadL(:, :, :) = dadL + didL
    !$omp end critical (get_damat_0d_)
-   deallocate(didL,didr,itrace)
+   deallocate(didL, didr, itrace)
    !$omp end parallel
 
 end subroutine get_damat_0d


### PR DESCRIPTION
Many thanks for this awesome software!

I've noticed an apparent leak of memory that occurs for a large number of energy+gradient evaluations (e.g. during long MD simulations or extensive sampling applications). 
For a handful of e+grd calls one barely notices it, but the memory consumption becomes severe over time, leading to swapping and eventually blows up the call:
![memory](https://github.com/tblite/tblite/assets/42216327/4b7b25c7-720b-4e92-b8ba-a8b6e119f108)

## How to reproduce?
The error can be easily reproduced with the `tblite` app, e.g. by simply building a loop around the `xtb_singlepoint` call. To reproduce it the gradient calculation (`--grad`) must be requested, a simple SCC without gradient does *not* show this.
Concerning technical setting: 
I've been using the latest  commit from the main branch (#152) and the build was created using
**meson 1.2.0** and **ifort 2021.9.0** with an MKL backend from the same oneAPI verison. 
The build was a static one, i.e., using `--default-library=static`, as well as Fortran link arguments `-static` and `-qopenmp`, but otherwise used the default build options.


## What was changed?
I've traced the memory consumption back to the OMP-parallel evaluation of the Coulomb matrix derivatives. My interpretation of what happens is that the implicit allocation of
```
   itrace = atrace
   didr = dadr
   didL = dadL
```
***within*** the OMP statement does not free up the respective memory correctly after execution of the subroutines `get_damat_3d` and `get_damat_0d`. This could be a problem endemic to the `ifort` build, but I'm not 100% sure about that. 
Allocating the three tensors *before* the OMP statement resolves the issue and even a few hundred thousand energy and gradient calls do not increase the memory consumption. 
![memory2](https://github.com/tblite/tblite/assets/42216327/37df82d9-3b49-4031-972a-aa10e57fa35e)

All builds and unit tests are passing, there is no other internal or external change to the behavior of the code. :+1: 