### PR TITLE
Use multiplicity as argument instead of spin

### DIFF
--- a/python/tblite/test_ase.py
+++ b/python/tblite/test_ase.py
@@ -244,5 +244,5 @@ def test_spgfn1_xtb():
     atoms.calc.set(spin_polarization=1.0)
     assert approx(atoms.get_potential_energy(), abs=thr) == -771.4322856679416
 
-    atoms.calc.set(spin=2)
+    atoms.calc.set(multiplicity=3)
     assert approx(atoms.get_potential_energy(), abs=thr) == -772.0011879234406


### PR DESCRIPTION
This is generally inconsistent in all calculators, let's opt for multiplicity here which is least confusing and most well defined.

Closes https://github.com/tblite/tblite/issues/159