### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: config/ci/doc-env.yml
 


### PR DESCRIPTION
Update in the doc build the micromamba action from the deprecated [provision-with-micromamba](https://github.com/mamba-org/provision-with-micromamba) to [setup-micromamba](https://github.com/mamba-org/setup-micromamba).