### PR TITLE
Pin dependency versions also in meson.build

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -123,7 +123,7 @@ lib_deps += mctc_dep
 # Create DFT-D4 library as subproject
 dftd4_dep = dependency(
   'dftd4',
-  version: '>=3.4.0 <4.0.0',
+  version: ['>=3.4.0', '<4'],
   fallback: ['dftd4', 'dftd4_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )

--- a/config/meson.build
+++ b/config/meson.build
@@ -114,7 +114,7 @@ endif
 # Create the tool chain library as subproject
 mctc_dep = dependency(
   'mctc-lib',
-  version: '0.3.2',
+  version: '>=0.3.0',
   fallback: ['mctc-lib', 'mctc_dep'],
   default_options: ['default_library=static'],
 )
@@ -123,7 +123,7 @@ lib_deps += mctc_dep
 # Create DFT-D4 library as subproject
 dftd4_dep = dependency(
   'dftd4',
-  version: '3.7.0',
+  version: '>=3.4.0',
   fallback: ['dftd4', 'dftd4_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )
@@ -132,7 +132,7 @@ lib_deps += dftd4_dep
 # Create DFT-D3 library as subproject
 sdftd3_dep = dependency(
   's-dftd3',
-  version: '1.2.0',
+  version: '>=0.6.0',
   fallback: ['s-dftd3', 'sdftd3_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )
@@ -141,7 +141,7 @@ lib_deps += sdftd3_dep
 # Create TOML Fortran as subproject
 tomlf_dep = dependency(
   'toml-f',
-  version: '0.4.1',
+  version: '>=0.4.0',
   fallback: ['toml-f', 'tomlf_dep'],
   default_options: ['default_library=static'],
 )

--- a/config/meson.build
+++ b/config/meson.build
@@ -123,7 +123,7 @@ lib_deps += mctc_dep
 # Create DFT-D4 library as subproject
 dftd4_dep = dependency(
   'dftd4',
-  version: '>=3.4.0',
+  version: '>=3.4.0 <4.0.0',
   fallback: ['dftd4', 'dftd4_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )

--- a/config/meson.build
+++ b/config/meson.build
@@ -114,7 +114,7 @@ endif
 # Create the tool chain library as subproject
 mctc_dep = dependency(
   'mctc-lib',
-  version: '>=0.3.0',
+  version: '0.3.2',
   fallback: ['mctc-lib', 'mctc_dep'],
   default_options: ['default_library=static'],
 )
@@ -123,7 +123,7 @@ lib_deps += mctc_dep
 # Create DFT-D4 library as subproject
 dftd4_dep = dependency(
   'dftd4',
-  version: '>=3.0.0',
+  version: '3.7.0',
   fallback: ['dftd4', 'dftd4_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )
@@ -132,6 +132,7 @@ lib_deps += dftd4_dep
 # Create DFT-D3 library as subproject
 sdftd3_dep = dependency(
   's-dftd3',
+  version: '1.2.0',
   fallback: ['s-dftd3', 'sdftd3_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )
@@ -140,7 +141,7 @@ lib_deps += sdftd3_dep
 # Create TOML Fortran as subproject
 tomlf_dep = dependency(
   'toml-f',
-  version: '>=0.4.0',
+  version: '0.4.1',
   fallback: ['toml-f', 'tomlf_dep'],
   default_options: ['default_library=static'],
 )

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -17,7 +17,7 @@
 # Create mstore as subproject for testing
 mstore_dep = dependency(
   'mstore',
-  version: '>=0.1',
+  version: '0.3.0',
   fallback: ['mstore', 'mstore_dep'],
   required: not meson.is_subproject(),
   default_options: [

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -17,7 +17,7 @@
 # Create mstore as subproject for testing
 mstore_dep = dependency(
   'mstore',
-  version: '0.3.0',
+  version: '>=0.3.0',
   fallback: ['mstore', 'mstore_dep'],
   required: not meson.is_subproject(),
   default_options: [


### PR DESCRIPTION
I also pinned the dependency versions in the meson.build files. We might want to use a ">=" but to allow for a xtb build where all dependencies are consistent, this seems to require specification here to. 