### PR TITLE
Atomic charges (`qat`) in `tblite.json` dump

### DIFF
--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -271,7 +271,7 @@ subroutine run_main(config, error)
       call ascii_levels(ctx%unit, config%verbosity, wfn%homo, wfn%emo, wfn%focc, 7)
       call post_proc%dict%get_entry("molecular-dipole", dpmom)
       call post_proc%dict%get_entry("molecular-quadrupole", qpmom)
-      
+
       call ascii_dipole_moments(ctx%unit, 1, mol, wfn%dpat(:, :, 1), dpmom)
       call ascii_quadrupole_moments(ctx%unit, 1, mol, wfn%qpat(:, :, 1), qpmom)
    end if
@@ -290,7 +290,7 @@ subroutine run_main(config, error)
    if (config%json) then
       open(file=config%json_output, newunit=unit)
       call json_results(unit, "  ", energy=energy, gradient=gradient, sigma=sigma, &
-         & energies=results%energies)
+         & energies=results%energies, charges=wfn%qat(:, 1))
       close(unit)
       if (config%verbosity > 0) then
          call info(ctx, "JSON dump of results written to '"//config%json_output//"'")


### PR DESCRIPTION
### What I want to have

- atomic charges (coming from `wfn%qat(:,1)`) in the `tblite.json` dump, accessible via `--json`

## "Naive" implementation

- see commit 

## "Right way" of doing it

... could probably also be via `add_post_processing` or similar. @awvwgk @pitsteinbach What do you think about it? 

Tbh, (even though that's a bit off-topic) I don't really understand how to access these post-processing results, e.g., Wiberg-Mayer bond orders via CLI as a `stdout` or via file dump. 😄 IMHO, they should be exported to the `JSON` file as well.