### PR TITLE
Add TBLiteValueError to dict() method in Results Container python

### DIFF
--- a/python/tblite/interface.py
+++ b/python/tblite/interface.py
@@ -25,7 +25,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 
 from . import library
-from .exceptions import TBLiteValueError
+from .exceptions import TBLiteValueError, TBLiteRuntimeError
 
 
 class Structure:
@@ -346,7 +346,7 @@ class Result:
         for key in self._getter:
             try:
                 res[key] = self.get(key)
-            except RuntimeError:
+            except (TBLiteValueError, TBLiteRuntimeError):
                 pass
 
         return res

--- a/python/tblite/library.py
+++ b/python/tblite/library.py
@@ -293,7 +293,7 @@ def get_dipole(res):
     """Retrieve dipole moment from post processing dictionary"""
     _dict = get_post_processing_dict(res=res)
     if not("molecular-dipole" in _dict.keys()):
-        raise ValueError(
+        raise TBLiteValueError(
                 f"Molecular dipole was not calculated. By default it is computed."
             )
     _dipole = _dict["molecular-dipole"]
@@ -304,7 +304,7 @@ def get_quadrupole(res):
     """Retrieve quadrupole moment from post processing dictionary"""
     _dict = get_post_processing_dict(res=res)
     if not("molecular-quadrupole" in _dict.keys()):
-        raise ValueError(
+        raise TBLiteValueError(
                 f"Molecular quadrupole was not calculated. By default it is computed."
             )
     _quadrupole = _dict["molecular-quadrupole"]

--- a/python/tblite/test_interface.py
+++ b/python/tblite/test_interface.py
@@ -18,7 +18,7 @@ from logging import Logger
 
 import numpy as np
 from pytest import approx, raises
-from tblite.exceptions import TBLiteRuntimeError
+from tblite.exceptions import TBLiteRuntimeError, TBLiteValueError
 from tblite.interface import Calculator, Result, symbols_to_numbers
 
 thr = 1.0e-9
@@ -461,16 +461,18 @@ def test_post_processing_api():
     calc = Calculator("GFN1-xTB", numbers, positions)
     calc.add("bond-orders")
     res = calc.singlepoint()
-    with raises(ValueError, match="Molecular dipole was not calculated. By default it is computed."):
+    with raises(TBLiteValueError, match="Molecular dipole was not calculated. By default it is computed."):
         res.get("dipole")
 
-    with raises(ValueError, match="Molecular quadrupole was not calculated. By default it is computed."):
+    with raises(TBLiteValueError, match="Molecular quadrupole was not calculated. By default it is computed."):
         res.get("quadrupole")
 
+    res.dict()
+    
     calc = Calculator("GFN1-xTB", numbers, positions)
     calc.add("molecular-multipoles")
     res = calc.singlepoint()
-    with raises(ValueError, match="Bond-orders were not calculated. By default they are computed."):
+    with raises(TBLiteValueError, match="Bond-orders were not calculated. By default they are computed."):
         res.get("bond-orders")
 
     calc = Calculator("GFN1-xTB", numbers, positions)


### PR DESCRIPTION
Currently part of the results throw a `ValueError` or `TBLiteValuError`, whereas other throw a RunTime Error if they are not contained in the results container. Now all the results coming from the dictionary use the `TBLiteValueError`, I also added it to the `Results.dict()` method as it returned an exception if a post-processing value is added manually.
I also added a check for this situation to `test_interface.py` and changed the error checking to the `TBLiteValueError` type.