### PR TITLE
Fill just allocated arrays with zeros

### DIFF
--- a/src/tblite/integral/type.f90
+++ b/src/tblite/integral/type.f90
@@ -51,11 +51,11 @@ subroutine new_integral(self, nao)
    !> Dimension of the integrals
    integer, intent(in) :: nao
 
-   allocate(self%hamiltonian(nao, nao))
-   allocate(self%overlap(nao, nao))
-   allocate(self%dipole(3, nao, nao))
-   allocate(self%quadrupole(6, nao, nao))
-   allocate(self%overlap_diat(nao, nao))
+   allocate(self%hamiltonian(nao, nao), source = 0.0_wp)
+   allocate(self%overlap(nao, nao), source = 0.0_wp)
+   allocate(self%dipole(3, nao, nao), source = 0.0_wp)
+   allocate(self%quadrupole(6, nao, nao), source = 0.0_wp)
+   allocate(self%overlap_diat(nao, nao), source = 0.0_wp)
 end subroutine new_integral
 
 end module tblite_integral_type


### PR DESCRIPTION
This PR fixes sometimes failing `xtb/ptb` test (`coulomb_pot` subtest) in https://github.com/grimme-lab/xtb repo. That is happens since allocate may return not a zero-filled arrays and therefore sometimes NaN can be in those arrays.

Before patch, I needed from 100 to 1500 runs of  `xtb/ptb` test to fail it. After patch, I did not catch any errors with 15000 repeats.