### PR TITLE
Fix creating efield interaction twice

### DIFF
--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -198,14 +198,6 @@ subroutine run_main(config, error)
    end select
    if (allocated(error)) return
 
-   if (allocated(config%efield)) then
-      block
-         class(container_type), allocatable :: cont
-         cont = electric_field(config%efield*vatoau)
-         call calc%push_back(cont)
-      end block
-   end if
-
    if (config%spin_polarized) then
       block
          class(container_type), allocatable :: cont


### PR DESCRIPTION
Driver created two electric field containers and pushed them to the calculator.
Now results align again with tblite<0.4.0.