### PR TITLE
Cleanup the xtbml imports

### DIFF
--- a/src/tblite/post_processing/list.f90
+++ b/src/tblite/post_processing/list.f90
@@ -18,25 +18,23 @@
 !> Implements post processing conatiner list, collcting post processing methods.
 module tblite_post_processing_list
    use mctc_env, only : wp, error_type, fatal_error
-   use tblite_post_processing_type, only : post_processing_type
-   use tblite_param_post_processing, only : post_processing_param_list
-   use tblite_toml, only : toml_error, toml_parse, toml_table, get_value
-   use tblite_param, only : param_record
-   use tblite_param_serde, only : serde_record
-   use tblite_wavefunction_type, only : wavefunction_type
+   use mctc_io, only : structure_type
    use tblite_context, only : context_type
-   use tblite_timer, only : timer_type, format_time
-   use tblite_xtb_calculator, only : xtb_calculator
    use tblite_container_cache, only : container_cache
    use tblite_double_dictionary, only : double_dictionary_type
-   use mctc_io, only : structure_type
    use tblite_integral_type, only : integral_type
-   use tblite_results, only : results_type
+   use tblite_param_molecular_moments, only : molecular_multipole_record
+   use tblite_param_post_processing, only : post_processing_param_list
+   use tblite_param_serde, only : serde_record
+   use tblite_param_xtbml_features, only : xtbml_features_record
    use tblite_post_processing_bond_orders, only : new_wbo, wiberg_bond_orders
    use tblite_post_processing_molecular_moments, only : new_molecular_moments, molecular_moments
-   use tblite_param_molecular_moments, only : molecular_multipole_record
-   use tblite_param_xtbml_features, only : xtbml_features_record
+   use tblite_post_processing_type, only : post_processing_type
    use tblite_post_processing_xtbml_features, only : xtbml_type, new_xtbml_features
+   use tblite_results, only : results_type
+   use tblite_toml, only : toml_error, toml_parse, toml_table, get_value
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
    implicit none
    private
 
@@ -44,7 +42,7 @@ module tblite_post_processing_list
 
    type :: post_processing_record
       class(post_processing_type), allocatable :: pproc
-   end type
+   end type post_processing_record
 
    type, public :: post_processing_list
       type(post_processing_record), allocatable :: list(:)
@@ -57,12 +55,12 @@ module tblite_post_processing_list
       procedure :: info
       procedure :: print_timer
       procedure :: push
-   end type
+   end type post_processing_list
 
    interface add_post_processing
       procedure :: add_post_processing_param
       procedure :: add_post_processing_cli
-   end interface
+   end interface add_post_processing
    logical :: print_csv_bool =.false.
 contains
 
@@ -75,7 +73,7 @@ subroutine print_timer(self, prlevel, ctx)
    do i = 1, self%n
       call self%list(i)%pproc%print_timer(prlevel, ctx)
    end do
-end subroutine
+end subroutine print_timer
 
 subroutine pack_res(self, mol, res)
    class(post_processing_list), intent(in) :: self
@@ -83,12 +81,12 @@ subroutine pack_res(self, mol, res)
    type(results_type), intent(inout) :: res
 
    res%dict = self%dict
-end subroutine
+end subroutine pack_res
 
 subroutine print_csv(self, mol)
    class(post_processing_list), intent(in) :: self
    type(structure_type) :: mol
-end subroutine
+end subroutine print_csv
 
 subroutine compute(self, mol, wfn, int, calc, c_list, ctx, prlevel)
    class(post_processing_list) :: self
@@ -108,7 +106,7 @@ subroutine compute(self, mol, wfn, int, calc, c_list, ctx, prlevel)
    do i = 1, self%n
       call self%list(i)%pproc%compute(mol, wfn, int, calc, c_list, ctx, prlevel, self%dict)
    end do
-end subroutine
+end subroutine compute
 
 pure function info(self, verbosity, indent) result(str)
    !> Instance of the interaction container
@@ -158,7 +156,7 @@ subroutine add_post_processing_param(self, param)
          end block
       end select
    end do
-end subroutine
+end subroutine add_post_processing_param
 
 subroutine add_post_processing_cli(self, config, error)
    class(post_processing_list), intent(inout) :: self
@@ -233,7 +231,7 @@ subroutine add_post_processing_cli(self, config, error)
       end block   
    end select
    call add_post_processing(self, param)
-end subroutine
+end subroutine add_post_processing_cli
 
 subroutine push(self, record)
    class(post_processing_list), intent(inout) :: self
@@ -259,7 +257,7 @@ function is_duplicate(self, record) result(duplicate)
    do i = 1, self%n
       if (record%label == self%list(i)%pproc%label) duplicate = .true.
    end do
-end function
+end function is_duplicate
 
 subroutine resize(list, n)
    !> Instance of the array to be resized
@@ -295,4 +293,5 @@ subroutine resize(list, n)
    end if
 
 end subroutine resize
-end module
+
+end module tblite_post_processing_list

--- a/src/tblite/post_processing/molmom.f90
+++ b/src/tblite/post_processing/molmom.f90
@@ -18,21 +18,20 @@
 !> Implements the calculation of molecular moments as post processing methods.
 module tblite_post_processing_molecular_moments
    use mctc_env, only : wp
-   use tblite_post_processing_type, only : post_processing_type
-   use tblite_wavefunction_type, only : wavefunction_type, get_density_matrix
    use mctc_io, only : structure_type
    use tblite_basis_type, only : basis_type
-   use tblite_results, only : results_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
-   use tblite_results, only : results_type
    use tblite_context, only : context_type
-   use tblite_xtb_calculator, only : xtb_calculator
    use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_timer, only : timer_type, format_time
+   use tblite_integral_type, only : integral_type
    use tblite_output_format, only : format_string
-   use tblite_wavefunction_mulliken, only : get_molecular_dipole_moment, get_molecular_quadrupole_moment
    use tblite_param_molecular_moments, only : molecular_multipole_record
+   use tblite_post_processing_type, only : post_processing_type
+   use tblite_results, only : results_type
+   use tblite_timer, only : timer_type, format_time
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_wavefunction_mulliken, only : get_molecular_dipole_moment, get_molecular_quadrupole_moment
    implicit none
    private
 
@@ -43,7 +42,7 @@ module tblite_post_processing_molecular_moments
    contains
       procedure :: compute
       procedure :: print_timer
-   end type
+   end type molecular_moments
 
    character(len=27), parameter :: label = "Molecular Multipole Moments"
    type(timer_type) :: timer
@@ -59,7 +58,7 @@ subroutine new_molecular_moments(new_molmom_type, param)
    new_molmom_type%comp_dipm = param%moldipm
    new_molmom_type%comp_qm = param%molqp
 
-end subroutine
+end subroutine new_molecular_moments
 
 subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, dict)
    class(molecular_moments),intent(inout) :: self
@@ -95,7 +94,7 @@ subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, di
       call timer%pop()
    end if
    call timer%pop()
-end subroutine
+end subroutine compute
 
 subroutine print_timer(self, prlevel, ctx)
    !> Instance of the interaction container
@@ -121,6 +120,6 @@ subroutine print_timer(self, prlevel, ctx)
       end do
       call ctx%message("")
    end if
-end subroutine
+end subroutine print_timer
 
-end module
+end module tblite_post_processing_molecular_moments

--- a/src/tblite/post_processing/type.f90
+++ b/src/tblite/post_processing/type.f90
@@ -18,17 +18,16 @@
 !> Implements post processing container abstract class, and the collection of computing caches.
 module tblite_post_processing_type
    use mctc_env, only : wp
-   use tblite_double_dictionary, only : double_dictionary_type
    use mctc_io, only : structure_type
    use tblite_basis_type, only : basis_type
-   use tblite_results, only : results_type
-   use tblite_integral_type, only : integral_type
-   use tblite_wavefunction_type, only : wavefunction_type
-   use tblite_results, only : results_type
-   use tblite_context, only : context_type
-   use tblite_timer, only : timer_type, format_time
-   use tblite_xtb_calculator, only : xtb_calculator
    use tblite_container_cache, only : container_cache
+   use tblite_context, only : context_type
+   use tblite_double_dictionary, only : double_dictionary_type
+   use tblite_integral_type, only : integral_type
+   use tblite_results, only : results_type
+   use tblite_timer, only : timer_type, format_time
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
    implicit none
    private
    public :: post_processing_type, collect_containers_caches
@@ -37,12 +36,11 @@ module tblite_post_processing_type
       character(len=:), allocatable :: label
 
    contains
-      !setup container
+      !> Setup container
       procedure(compute), deferred :: compute
       procedure :: info
       procedure :: print_timer
-      !print toml could be possible
-   end type
+   end type  post_processing_type
 
    type(timer_type) :: timer
    abstract interface
@@ -66,10 +64,9 @@ module tblite_post_processing_type
       integer, intent(in) :: prlevel
       !> Dictionary for storing results
       type(double_dictionary_type), intent(inout) :: dict
-      end subroutine
+      end subroutine compute
    end interface
 contains
-
 
 
 pure function info(self, verbosity, indent) result(str)
@@ -103,7 +100,7 @@ subroutine print_timer(self, prlevel, ctx)
       call ctx%message(" total:"//repeat(" ", 16)//format_time(ttime))
       call ctx%message("")
    end if
-end subroutine
+end subroutine print_timer
 
 subroutine collect_containers_caches(rcache, ccache, hcache, dcache, icache, calc, cache_list)
    type(container_cache), allocatable, intent(inout) :: rcache, ccache, hcache, dcache, icache
@@ -116,6 +113,6 @@ subroutine collect_containers_caches(rcache, ccache, hcache, dcache, icache, cal
    if (allocated(calc%halogen)) call move_alloc(hcache%raw, cache_list(3)%raw)
    if (allocated(calc%dispersion)) call move_alloc(dcache%raw, cache_list(4)%raw)
    if (allocated(calc%interactions)) call move_alloc(icache%raw, cache_list(5)%raw)
-end subroutine
+end subroutine collect_containers_caches
 
 end module tblite_post_processing_type

--- a/src/tblite/post_processing/wbo.f90
+++ b/src/tblite/post_processing/wbo.f90
@@ -18,20 +18,19 @@
 !> Implements the calculation of Wiberg-Mayer bond orders as post processing method.
 module tblite_post_processing_bond_orders
    use mctc_env, only : wp
-   use tblite_post_processing_type, only : post_processing_type
-   use tblite_wavefunction_type, only : wavefunction_type, get_density_matrix
-   use tblite_wavefunction_mulliken, only : get_mayer_bond_orders, get_mayer_bond_orders_uhf
    use mctc_io, only : structure_type
    use tblite_basis_type, only : basis_type
-   use tblite_results, only : results_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
-   use tblite_results, only : results_type
    use tblite_context, only : context_type
-   use tblite_xtb_calculator, only : xtb_calculator
    use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_timer, only : timer_type, format_time
+   use tblite_integral_type, only : integral_type
    use tblite_output_format, only : format_string
+   use tblite_post_processing_type, only : post_processing_type
+   use tblite_results, only : results_type
+   use tblite_timer, only : timer_type, format_time
+   use tblite_wavefunction_type, only : wavefunction_type, get_density_matrix
+   use tblite_wavefunction_mulliken, only : get_mayer_bond_orders, get_mayer_bond_orders_uhf
+   use tblite_xtb_calculator, only : xtb_calculator
    implicit none
    private
 
@@ -41,7 +40,7 @@ module tblite_post_processing_bond_orders
    contains
       procedure :: compute
       procedure :: print_timer
-   end type
+   end type wiberg_bond_orders
 
    character(len=24), parameter :: label = "Mayer-Wiberg bond orders"
    type(timer_type) :: timer
@@ -50,7 +49,7 @@ contains
 subroutine new_wbo(new_wbo_type)
    type(wiberg_bond_orders), intent(inout) :: new_wbo_type
    new_wbo_type%label = label
-end subroutine
+end subroutine new_wbo
 
 subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, dict)
    class(wiberg_bond_orders),intent(inout) :: self
@@ -114,7 +113,7 @@ subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, di
 
    
    call timer%pop()
-end subroutine
+end subroutine compute
 
 subroutine print_timer(self, prlevel, ctx)
    !> Instance of the interaction container
@@ -137,6 +136,6 @@ subroutine print_timer(self, prlevel, ctx)
       end do
       call ctx%message("")
    end if
-end subroutine
+end subroutine print_timer
 
-end module
+end module tblite_post_processing_bond_orders

--- a/src/tblite/post_processing/xtb-ml/atomic_frontier_orbitals.f90
+++ b/src/tblite/post_processing/xtb-ml/atomic_frontier_orbitals.f90
@@ -17,11 +17,7 @@
 
 !> compute atomic response function and effective H-L gap
 module tblite_xtbml_atomic_frontier
-   use mctc_io_convert, only : autoev
-   use tblite_timer, only : timer_type, format_time
-   use tblite_context, only : context_type
    use mctc_env, only : wp, sp
-   use tblite_output_format, only : format_string
    implicit none
    private
    public :: atomic_frontier_orbitals

--- a/src/tblite/post_processing/xtb-ml/convolution.f90
+++ b/src/tblite/post_processing/xtb-ml/convolution.f90
@@ -39,7 +39,7 @@ module tblite_xtbml_convolution
       procedure, private :: get_rcov
       procedure, private :: compute_cn
       procedure :: info
-   end type
+   end type xtbml_convolution_type
    character(len=*), parameter :: label = "CN-based convolution"
 
 
@@ -48,7 +48,7 @@ contains
 subroutine setup(self)
    class(xtbml_convolution_type), intent(inout) :: self
    self%label = label
-end subroutine
+end subroutine setup
 
 !> Compute values of the convolution kernel
 subroutine compute_kernel(self, mol)
@@ -61,7 +61,7 @@ subroutine compute_kernel(self, mol)
    call self%populate_kernel(mol%id, mol%xyz)
    call self%compute_cn(mol)
 
-end subroutine
+end subroutine compute_kernel
 
 !> Compute the CN
 subroutine compute_cn(self, mol)
@@ -77,7 +77,7 @@ subroutine compute_cn(self, mol)
       call new_exp_ncoord(ncoord_exp, mol, rcov=self%rcov*self%a(i))
       call ncoord_exp%get_cn(mol, self%cn(:, i))
    end do
-end subroutine
+end subroutine compute_cn
 
 !> Get the covalent radii
 subroutine get_rcov(self, mol)
@@ -90,7 +90,7 @@ subroutine get_rcov(self, mol)
    end if
    allocate (self%rcov(mol%nid), source=0.0_wp)
    self%rcov(:) = get_covalent_rad(mol%num)
-end subroutine
+end subroutine get_rcov
 
 !> Populate the kernel
 subroutine populate_kernel(self, at, xyz)
@@ -151,7 +151,7 @@ subroutine inv_cn(self, a, b, at, xyz, dampening_fact, result)
 
    result = 1.0_wp/exp_count(k1, r, rco)
 
-end subroutine
+end subroutine inv_cn
 
 !> Exponential counting function from D3
 pure elemental function exp_count(k, r, r0) result(count)

--- a/src/tblite/post_processing/xtb-ml/density.f90
+++ b/src/tblite/post_processing/xtb-ml/density.f90
@@ -17,18 +17,15 @@
 !> Desnity based fetaures using Mulliken partitioning
 module tblite_xtbml_density_based
    use mctc_env, only : wp
-   use tblite_xtbml_feature_type, only : xtbml_feature_type
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
-   use tblite_context , only : context_type
-   use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
-   use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_ncoord_exp, only : new_exp_ncoord, exp_ncoord_type
-   use tblite_wavefunction_mulliken, only : get_mulliken_shell_multipoles
+   use tblite_integral_type, only : integral_type
    use tblite_output_format, only : format_string
+   use tblite_wavefunction_mulliken, only : get_mulliken_shell_multipoles
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
+   use tblite_xtbml_feature_type, only : xtbml_feature_type
    implicit none
    private
    character(len=*), parameter :: label = "density-based features"
@@ -78,7 +75,7 @@ module tblite_xtbml_density_based
       procedure, private :: allocate
       procedure, private :: allocate_extended
       procedure :: setup
-   end type
+   end type xtbml_density_features_type
 
 contains
 
@@ -89,7 +86,7 @@ subroutine setup(self)
    allocate(self%dict)
    if (allocated(self%dict_ext)) deallocate(self%dict_ext)
    allocate(self%dict_ext)
-end subroutine
+end subroutine setup
 
 subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    !> Instance of the feature container
@@ -130,9 +127,9 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    do spin = 1, nspin
       self%partial_charge_atom(:, spin) = -self%partial_charge_atom(:, spin)+z/nspin
    end do
-   !dipole moments shellwise and then atomwise
+   ! dipole moments shellwise and then atomwise
    call get_mulliken_shell_multipoles(calc%bas, integrals%dipole, wfn%density, self%dipm_shell_xyz)
-   !quadrupole moments shellwise and then atomwise
+   ! quadrupole moments shellwise and then atomwise
    call get_mulliken_shell_multipoles(calc%bas, integrals%quadrupole, wfn%density, &
    & self%qm_shell_xyz)
    ! get atomic dipole moments from wavefunctin object
@@ -200,7 +197,7 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
          end if
       end associate
    end do
-end subroutine
+end subroutine compute_features
 
 !> get the screened nuclear charge for each atom
 ! which means the nuclear charge minus the core charge
@@ -280,7 +277,7 @@ subroutine resolve_shellwise(shell_prop, array_s, array_p, array_d, at2nsh)
          nsh = nsh + 1
       end if
    end do
-end subroutine
+end subroutine resolve_shellwise
 
 !> separate a vector of properties for all shells into separate arrays for each shell type, for tensorial properties
 subroutine resolve_xyz_shell(mult_xyz, array, at2nsh)
@@ -331,7 +328,7 @@ subroutine resolve_xyz_shell(mult_xyz, array, at2nsh)
          nsh = nsh + 1
       end if
    end do
-end subroutine
+end subroutine resolve_xyz_shell
 
 subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolution) 
    !> Instance of feature container
@@ -466,7 +463,7 @@ subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolu
          end do
       end associate
    end do
-end subroutine
+end subroutine compute_extended
 
 !> Allocate features
 subroutine allocate(self, nsh, nat, nspin)
@@ -490,7 +487,7 @@ subroutine allocate(self, nsh, nat, nspin)
    allocate(self%dipm_atom_xyz(3, nat, nspin), source=0.0_wp)
    allocate(self%qm_shell_xyz(6, nsh, nspin), source=0.0_wp)
    allocate(self%qm_atom_xyz(6, nat, nspin), source=0.0_wp)
-end subroutine
+end subroutine allocate
    
 !> Allocate extended features
 subroutine allocate_extended(self, nsh, nat, n_a)
@@ -519,7 +516,7 @@ subroutine allocate_extended(self, nsh, nat, n_a)
    allocate(self%ext_dipm_Z_xyz(3, nat, n_a), source=0.0_wp)
    allocate(self%ext_qm_Z_xyz(6, nat, n_a), source=0.0_wp)
 
-end subroutine
+end subroutine allocate_extended
 
 !> Compute shellwise mulliken charges
 subroutine mulliken_shellwise(ao2shell, p, s, charges_shell)
@@ -546,7 +543,7 @@ subroutine mulliken_shellwise(ao2shell, p, s, charges_shell)
       end do
    end do
 
-end subroutine
+end subroutine mulliken_shellwise
 
 !> Compute the extended atomic partial charges
 subroutine get_ext_partial_charge(atom_partial, xyz, conv, ext_partial)
@@ -576,7 +573,7 @@ subroutine get_ext_partial_charge(atom_partial, xyz, conv, ext_partial)
       enddo
    enddo
 
-end subroutine
+end subroutine get_ext_partial_charge
 
 !> summing up the mulliken charges to get atomic charges
 subroutine sum_up_mulliken(ash, mull_shell, mull_at)
@@ -594,7 +591,7 @@ subroutine sum_up_mulliken(ash, mull_shell, mull_at)
       mull_at(ash(i), :) = mull_at(ash(i), :) + mull_shell(i, :)
    end do
 
-end subroutine
+end subroutine sum_up_mulliken
 
 !> Compute the norm for extended dipole and quadrupole moments
 subroutine get_ext_mm(q, dipm, qp, at, xyz, conv, ext_dipm, ext_qp)
@@ -672,7 +669,7 @@ subroutine get_ext_mm(q, dipm, qp, at, xyz, conv, ext_dipm, ext_qp)
 
    call remove_trac_qp(ext_qp, qp_part)
 
-end subroutine
+end subroutine get_ext_mm
 
 !> Compute the norm for extended dipole and quadrupole moments
 subroutine comp_norm_3(dipm, qm, dipm_norm, qm_norm)
@@ -705,7 +702,7 @@ subroutine comp_norm_3(dipm, qm, dipm_norm, qm_norm)
    r = sqrt(r2)
    qm_norm(:, :) = r(:, :)
 
-end subroutine
+end subroutine comp_norm_3
 
 !> Compute extended quadrupole moment only due to nuclear effects
 ! all effects due to the electrons are set to 0, only the distribution of positive charges is left
@@ -772,7 +769,7 @@ subroutine get_ext_mm_Z(q, dipm, qp, at, xyz, conv, ext_dipm, ext_qp)
 
    call remove_trac_qp(ext_qp, qp_part)
 
-end subroutine
+end subroutine get_ext_mm_Z
 
 !> Compute extended quadrupole moment only due to electronic effects
 subroutine get_ext_mm_p(q, dipm, qp, at, xyz, conv, ext_dipm, ext_qp) ! the sign of q was changed to respect the charge of the electrons
@@ -844,7 +841,7 @@ subroutine get_ext_mm_p(q, dipm, qp, at, xyz, conv, ext_dipm, ext_qp) ! the sign
 
    call remove_trac_qp(ext_qp, qp_part)
 
-end subroutine
+end subroutine get_ext_mm_p
 
 !> Remove the trace of the quadrupole moment
 subroutine remove_trac_qp(qp_matrix, qp_part)
@@ -865,6 +862,6 @@ subroutine remove_trac_qp(qp_matrix, qp_part)
       qp_matrix(6, i, :) = qp_matrix(6, i, :) - tii
       qp_matrix(:, i, :) = qp_matrix(:, i, :) + qp_part(:, i, :)
    end do
-end subroutine
+end subroutine remove_trac_qp
 
 end module tblite_xtbml_density_based

--- a/src/tblite/post_processing/xtb-ml/energy.f90
+++ b/src/tblite/post_processing/xtb-ml/energy.f90
@@ -17,25 +17,18 @@
 !> Energy-based features
 module tblite_xtbml_energy_features
    use mctc_env, only : wp
-   use mctc_io_convert, only : autoev
-   use tblite_xtbml_feature_type, only : xtbml_feature_type
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
-   use tblite_integral_type, only : integral_type
    use tblite_basis_type, only : basis_type
-   use tblite_container, only : container_cache
-   use tblite_context , only : context_type
-   use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
-   use tblite_xtbml_atomic_frontier, only : atomic_frontier_orbitals
-   use tblite_container, only : container_type
-   use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_repulsion, only : tb_repulsion
-   use tblite_xtb_coulomb, only : tb_coulomb
-   use tblite_scf_iterator, only : get_electronic_energy, reduce
    use tblite_disp_d3, only : d3_dispersion, new_d3_dispersion
-   use tblite_classical_halogen, only : halogen_correction
    use tblite_disp_d4, only : d4_dispersion, new_d4_dispersion
+   use tblite_container, only : container_type, container_cache
+   use tblite_integral_type, only : integral_type
+   use tblite_scf_iterator, only : get_electronic_energy, reduce
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtb_coulomb, only : tb_coulomb
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
+   use tblite_xtbml_feature_type, only : xtbml_feature_type
    implicit none
    private
    character(len=*), parameter :: label = "energy-based features"
@@ -45,9 +38,10 @@ module tblite_xtbml_energy_features
       procedure :: compute_features
       procedure :: compute_extended
       procedure :: setup
-   end type
+   end type xtbml_energy_features_type
 
 contains
+
 !> Setup energy-based features
 subroutine setup(self)
    class(xtbml_energy_features_type) :: self
@@ -56,7 +50,8 @@ subroutine setup(self)
    allocate(self%dict)
    if (allocated(self%dict_ext)) deallocate(self%dict_ext)
    allocate(self%dict_ext)
-end subroutine
+end subroutine setup
+
 !> Compute energy-based features! all contributions to the molecular energy are computed here, and stored in the feature container
 subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    !> Instance of feature container
@@ -189,7 +184,8 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    call self%dict%add_entry("E_tot", tot_energy)
    call self%dict%add_entry("w_tot", tot_energy/sum(tot_energy))
 
-end subroutine
+end subroutine compute_features
+
 !> Compute extended energy-based features, empty for now
 subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolution)
    !> Instance of feature container
@@ -206,6 +202,6 @@ subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolu
    type(container_cache), intent(inout) :: cache_list(:)
    !> Convolution container
    type(xtbml_convolution_type), intent(in) :: convolution
-end subroutine
+end subroutine compute_extended
 
-   end module
+end module tblite_xtbml_energy_features

--- a/src/tblite/post_processing/xtb-ml/features.f90
+++ b/src/tblite/post_processing/xtb-ml/features.f90
@@ -17,14 +17,14 @@
 !> Abstract base class for xtb based features
 module tblite_xtbml_feature_type
    use mctc_env, only : wp
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
    use tblite_context , only : context_type
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
    use tblite_double_dictionary, only : double_dictionary_type
+   use tblite_integral_type, only : integral_type
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
    use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_wavefunction_type, only : wavefunction_type
    implicit none
    private
 
@@ -58,7 +58,8 @@ module tblite_xtbml_feature_type
          type(xtb_calculator), intent(in) :: calc
          !> Cache list for storing caches of various interactions
          type(container_cache), intent(inout) :: cache_list(:)
-      end subroutine
+      end subroutine compute_features
+
       subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolution)
          import :: wp, wavefunction_type, structure_type, integral_type, xtb_calculator,&
          & container_cache, context_type, xtbml_feature_type, xtbml_convolution_type
@@ -76,7 +77,7 @@ module tblite_xtbml_feature_type
          type(container_cache), intent(inout) :: cache_list(:)
          !> Convolution container
          type(xtbml_convolution_type), intent(in) :: convolution
-      end subroutine
+      end subroutine compute_extended
 
    end interface
 
@@ -85,7 +86,7 @@ contains
 subroutine setup(self)
    class(xtbml_feature_type) :: self
    self%label = label
-end subroutine
+end subroutine setup
 
 function get_n_features(self) result(n)
    class(xtbml_feature_type) :: self
@@ -93,7 +94,7 @@ function get_n_features(self) result(n)
 
    n = self%dict%get_n_entries()
    n = n + self%dict_ext%get_n_entries()
-end function
+end function get_n_features
 
 pure function info(self, verbosity, indent) result(str)
    !> Instance of the interaction container
@@ -112,5 +113,4 @@ pure function info(self, verbosity, indent) result(str)
    end if
 end function info
 
-
-end module
+end module tblite_xtbml_feature_type

--- a/src/tblite/post_processing/xtb-ml/geometry.f90
+++ b/src/tblite/post_processing/xtb-ml/geometry.f90
@@ -17,17 +17,15 @@
 !> Geometry based xtbml features
 module tblite_xtbml_geometry_based
    use mctc_env, only : wp
-   use tblite_xtbml_feature_type, only : xtbml_feature_type
-   use mctc_env, only : wp
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
-   use tblite_context , only : context_type
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
-   use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_ncoord_exp, only : new_exp_ncoord, exp_ncoord_type
+   use tblite_integral_type, only : integral_type
    use tblite_output_format, only : format_string
+   use tblite_ncoord_exp, only : new_exp_ncoord, exp_ncoord_type
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
+   use tblite_xtbml_feature_type, only : xtbml_feature_type
    implicit none
    private
 
@@ -44,7 +42,7 @@ module tblite_xtbml_geometry_based
       procedure :: compute_features
       procedure :: compute_extended
       procedure :: setup
-   end type
+   end type xtbml_geometry_features_type
 
 contains
 
@@ -58,7 +56,7 @@ subroutine setup(self)
    allocate(self%dict_ext)
    if (allocated(self%cn_atom)) deallocate(self%cn_atom)
    if (allocated(self%ext_cn)) deallocate(self%ext_cn)
-end subroutine
+end subroutine setup
 
 !> Compute geometry-based features
 subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
@@ -85,7 +83,7 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
 
    call self%dict%add_entry("CN_A", self%cn_atom)
 
-end subroutine
+end subroutine compute_features
 
 subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolution)
    !> Instance of feature container
@@ -114,7 +112,7 @@ subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolu
       if (tmp_label .eq. "ext_CN_A_1.00") tmp_label = "ext_CN"
       call self%dict_ext%add_entry(tmp_label, self%ext_cn(:, j))
    end do
-end subroutine
+end subroutine compute_extended
 
 subroutine get_ext_cn(cn, xyz, ext_cn, conv)
    !> Coordinated number
@@ -144,5 +142,6 @@ subroutine get_ext_cn(cn, xyz, ext_cn, conv)
       end do
    end do
    !$omp end parallel do
-end subroutine
+end subroutine get_ext_cn
+
 end module tblite_xtbml_geometry_based

--- a/src/tblite/post_processing/xtb-ml/orbital_energy.f90
+++ b/src/tblite/post_processing/xtb-ml/orbital_energy.f90
@@ -17,18 +17,16 @@
 !> Orbital energy based xtbml features
 module tblite_xtbml_orbital_energy
    use mctc_env, only : wp
-   use mctc_io_convert, only : autoev
-   use tblite_xtbml_feature_type, only : xtbml_feature_type
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
-   use tblite_integral_type, only : integral_type
-   use tblite_xtb_calculator, only : xtb_calculator
+   use mctc_io_convert, only : autoev
    use tblite_container, only : container_cache
-   use tblite_context , only : context_type
-   use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
-   use tblite_xtbml_atomic_frontier, only : atomic_frontier_orbitals
+   use tblite_integral_type, only : integral_type
    use tblite_output_format, only : format_string
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtbml_atomic_frontier, only : atomic_frontier_orbitals
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
+   use tblite_xtbml_feature_type, only : xtbml_feature_type
    implicit none
    private
    character(len=*), parameter :: label = "orbital energy-based features"
@@ -49,7 +47,7 @@ module tblite_xtbml_orbital_energy
       procedure, private :: allocate
       procedure, private :: allocate_extended
       procedure :: setup
-   end type
+   end type xtbml_orbital_features_type
 
 contains
 
@@ -61,7 +59,7 @@ subroutine setup(self)
    allocate(self%dict)
    if (allocated(self%dict_ext)) deallocate(self%dict_ext)
    allocate(self%dict_ext)
-end subroutine
+end subroutine setup
 
 !> Allocate memory for the features
 subroutine allocate(self, nat, nspin)
@@ -78,7 +76,7 @@ subroutine allocate(self, nat, nspin)
    allocate(self%ehoao(nat), source=0.0_wp)
    allocate(self%eluao(nat), source=0.0_wp)
 
-end subroutine
+end subroutine allocate
 
 !> Allocate memory for the extended features
 subroutine allocate_extended(self, nat, n_a)
@@ -94,7 +92,7 @@ subroutine allocate_extended(self, nat, n_a)
    allocate(self%ext_eluao(nat, n_a), source=0.0_wp)
    allocate(self%ext_ehoao(nat, n_a), source=0.0_wp)
 
-end subroutine
+end subroutine allocate_extended
 
 subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    !> Instance of feature container
@@ -167,7 +165,7 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
          call dict%add_entry(trim("LUAO"//spin_label(spin)), self%eluao)
       end associate
    end do
-end subroutine
+end subroutine compute_features
 
 subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolution)
    !> Instance of feature container
@@ -221,7 +219,7 @@ subroutine compute_extended(self, mol, wfn, integrals, calc, cache_list, convolu
          end do
       end associate
    end do
-end subroutine
+end subroutine compute_extended
 
 subroutine get_beta(kernel, cn, beta)
    intrinsic :: sum
@@ -249,7 +247,7 @@ subroutine get_beta(kernel, cn, beta)
       end do
    end do
    
-end subroutine
+end subroutine get_beta
 
 !> Get the extended chemical potential
 subroutine get_chem_pot_ext(beta, chempot, chempot_ext)
@@ -269,7 +267,7 @@ subroutine get_chem_pot_ext(beta, chempot, chempot_ext)
          end do
       end do
    end do
-end subroutine
+end subroutine get_chem_pot_ext
 
 !> Get the extended energy gap
 subroutine get_e_gap_ext(beta, e_gap, e_gap_ext)
@@ -290,7 +288,7 @@ subroutine get_e_gap_ext(beta, e_gap, e_gap_ext)
       end do
    end do
    
-end subroutine
+end subroutine get_e_gap_ext
 
 !> Compute the extended HOAO 
 subroutine get_ehoao_ext(chempot_ext, e_gap_ext, ehoao_ext)
@@ -306,7 +304,7 @@ subroutine get_ehoao_ext(chempot_ext, e_gap_ext, ehoao_ext)
          ehoao_ext(a, k) = chempot_ext(a, k) - e_gap_ext(a, k) / 2.0_wp
       end do
    end do
-end subroutine
+end subroutine get_ehoao_ext
 
 !> Compute the extended LUAO
 subroutine get_eluao_ext(chempot_ext, e_gap_ext, eluao_ext)
@@ -322,6 +320,6 @@ subroutine get_eluao_ext(chempot_ext, e_gap_ext, eluao_ext)
          eluao_ext(a, k) = chempot_ext(a, k) + e_gap_ext(a, k) / 2.0_wp
       end do
    end do
-end subroutine
+end subroutine get_eluao_ext
 
-end module
+end module tblite_xtbml_orbital_energy

--- a/src/tblite/post_processing/xtb-ml/xtbml.f90
+++ b/src/tblite/post_processing/xtb-ml/xtbml.f90
@@ -17,24 +17,23 @@
 !> File to collect all xtbml features
 module tblite_post_processing_xtbml_features
    use mctc_env, only : wp
-   use tblite_xtbml_convolution, only : xtbml_convolution_type
-   use tblite_xtbml_geometry_based, only : xtbml_geometry_features_type
-   use tblite_xtbml_density_based, only : xtbml_density_features_type
-   use tblite_wavefunction_type, only : wavefunction_type
    use mctc_io, only : structure_type
    use tblite_basis_type, only : basis_type
-   use tblite_results, only : results_type
-   use tblite_integral_type, only : integral_type
    use tblite_container, only : container_cache
    use tblite_context, only : context_type
    use tblite_double_dictionary, only : double_dictionary_type
-   use tblite_xtbml_orbital_energy, only : xtbml_orbital_features_type
-   use tblite_xtbml_energy_features, only : xtbml_energy_features_type
-   use tblite_timer, only : timer_type, format_time
-   use tblite_output_format, only : format_string
-   use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_post_processing_type, only : post_processing_type
+   use tblite_integral_type, only : integral_type
    use tblite_param_xtbml_features, only : xtbml_features_record
+   use tblite_post_processing_type, only : post_processing_type
+   use tblite_output_format, only : format_string
+   use tblite_timer, only : timer_type, format_time
+   use tblite_wavefunction_type, only : wavefunction_type
+   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtbml_convolution, only : xtbml_convolution_type
+   use tblite_xtbml_density_based, only : xtbml_density_features_type
+   use tblite_xtbml_energy_features, only : xtbml_energy_features_type
+   use tblite_xtbml_geometry_based, only : xtbml_geometry_features_type
+   use tblite_xtbml_orbital_energy, only : xtbml_orbital_features_type
    implicit none
    private
    public :: xtbml_type, new_xtbml_features
@@ -48,7 +47,7 @@ module tblite_post_processing_xtbml_features
       procedure :: compute
       procedure :: info
       procedure :: print_timer
-   end type
+   end type xtbml_type
    character(len=*), parameter :: label = "  xtbml features:"
    type(timer_type) :: timer
 contains
@@ -91,7 +90,7 @@ subroutine new_xtbml_features(new_xtbml_model, param)
       call new_xtbml_model%conv%setup()
    end if
 
-end subroutine
+end subroutine new_xtbml_features
 
 subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, dict)
    class(xtbml_type),intent(inout) :: self
@@ -191,7 +190,7 @@ subroutine compute(self, mol, wfn, integrals, calc, cache_list, ctx, prlevel, di
       end if
    end if
    call timer%pop()
-end subroutine
+end subroutine compute
 
 pure function info(self, verbosity, indent) result(str)
    !> Instance of the interaction container
@@ -244,8 +243,6 @@ subroutine print_timer(self, prlevel, ctx)
    & "geometry", "density", "orbital energy", "energy", "geometry convolution", &
       "density convolution", "orbital energy convolution"]
 
-
-
    if (prlevel > 2) then
       call ctx%message("ML features timing details:")
       ttime = timer%get("total")
@@ -258,6 +255,6 @@ subroutine print_timer(self, prlevel, ctx)
       end do
       call ctx%message("")
    end if
-end subroutine
+end subroutine print_timer
 
 end module tblite_post_processing_xtbml_features

--- a/test/unit/main.f90
+++ b/test/unit/main.f90
@@ -20,20 +20,22 @@ program tester
    use mctc_env, only : get_argument
    use mctc_env_testing, only : run_testsuite, new_testsuite, testsuite_type, &
       & select_suite, run_selected
+   use test_ceh, only : collect_ceh
    use test_cgto_ortho, only : collect_cgto_ortho
    use test_coulomb_charge, only : collect_coulomb_charge
    use test_coulomb_thirdorder, only : collect_coulomb_thirdorder
    use test_coulomb_multipole, only : collect_coulomb_multipole
+   use test_double_dictionary, only : collect_double_dictionary
    use test_fit, only : collect_fit
    use test_gfn1_xtb, only : collect_gfn1_xtb
    use test_gfn2_xtb, only : collect_gfn2_xtb
-   use test_ceh, only : collect_ceh
    use test_hamiltonian, only : collect_hamiltonian
    use test_halogen, only : collect_halogen
    use test_integral_multipole, only : collect_integral_multipole
    use test_integral_overlap, only : collect_integral_overlap
    use test_ipea1_xtb, only : collect_ipea1_xtb
    use test_ncoord, only : collect_ncoord
+   use test_post_processing, only : collect_post_processing
    use test_repulsion, only : collect_repulsion
    use test_slater_expansion, only : collect_slater_expansion
    use test_spin, only : collect_spin
@@ -45,9 +47,7 @@ program tester
    use test_tagged_io, only : collect_tagged_io
    use test_xtb_external, only : collect_xtb_external
    use test_xtb_param, only : collect_xtb_param
-   use test_double_dictionary, only : collect_double_dictionary
-   use tblite_test_post_processing, only : collect_post_processing
-   use tblite_test_xtbml, only : collect_xtbml
+   use test_xtbml, only : collect_xtbml
    implicit none
    integer :: stat, is
    character(len=:), allocatable :: suite_name, test_name

--- a/test/unit/test_post_processing.f90
+++ b/test/unit/test_post_processing.f90
@@ -1,19 +1,18 @@
-module tblite_test_post_processing
+module test_post_processing
    use mctc_env, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check, &
       & test_failed
    use mctc_io, only : structure_type, new
    use tblite_context_type, only : context_type
+   use tblite_param_molecular_moments, only:  molecular_multipole_record
+   use tblite_param_post_processing, only : post_processing_param_list
+   use tblite_post_processing_list, only : post_processing_list, add_post_processing
+   use tblite_results, only : results_type
+   use tblite_toml, only : toml_table, add_table, set_value, toml_key, get_value
    use tblite_wavefunction, only : wavefunction_type, new_wavefunction, eeq_guess
    use tblite_xtb_calculator, only : xtb_calculator
    use tblite_xtb_gfn2, only : new_gfn2_calculator
    use tblite_xtb_singlepoint, only : xtb_singlepoint
-   use tblite_post_processing_list, only : post_processing_list, add_post_processing
-   use tblite_results, only : results_type
-   use tblite_param, only : param_record
-   use tblite_toml, only : toml_table, add_table, toml_value, set_value, toml_key, get_value
-   use tblite_param_molecular_moments, only:  molecular_multipole_record
-   use tblite_param_post_processing, only : post_processing_param_list
    implicit none
    private
 
@@ -82,7 +81,6 @@ subroutine test_h2_wbo(error)
          print'("---")'
          print'(3es21.14)', wbo_exp
    end if
-   
 
    mol%charge = 0.0_wp
    mol%uhf = 0
@@ -132,7 +130,7 @@ subroutine test_h2_wbo(error)
          print'(3es21.14)', wbo_exp
    end if
 
-end subroutine
+end subroutine test_h2_wbo
 
 subroutine test_timer_print(error)
    type(error_type), allocatable, intent(out) :: error
@@ -163,7 +161,8 @@ subroutine test_timer_print(error)
    energy = 0.0_wp
    
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, results=res, post_process=pproc, verbosity=3)
-end subroutine
+
+end subroutine test_timer_print
 
 subroutine test_molmom_dipm_param(error)
    type(error_type), allocatable, intent(out) :: error
@@ -183,8 +182,7 @@ subroutine test_molmom_dipm_param(error)
    
    call param%load(table_post_proc, error)
    
-
-end subroutine
+end subroutine test_molmom_dipm_param
 
 subroutine test_molmom_qp_param(error)
    type(error_type), allocatable, intent(out) :: error
@@ -199,7 +197,7 @@ subroutine test_molmom_qp_param(error)
    
    call param%load(table_post_proc, error)
    
-end subroutine
+end subroutine test_molmom_qp_param
 
 subroutine test_molmom_dump_param(error)
    type(error_type), allocatable, intent(out) :: error
@@ -232,7 +230,7 @@ subroutine test_molmom_dump_param(error)
    call check(error, size(list), 2)
    if (allocated(error)) return
    
-end subroutine
+end subroutine test_molmom_dump_param
 
 subroutine test_pproc_load_param(error)
    type(error_type), allocatable, intent(out) :: error
@@ -246,7 +244,7 @@ subroutine test_pproc_load_param(error)
    call set_value(table_entries, "quadrupole", .false.)
    call param%load(table_multipole, error)
 
-end subroutine
+end subroutine test_pproc_load_param
 
 subroutine test_pproc_dump_param(error)
    type(error_type), allocatable, intent(out) :: error
@@ -272,7 +270,7 @@ subroutine test_pproc_dump_param(error)
    call child%get_keys(list)
    call check(error, size(list), 2)
    if (allocated(error)) return
-end subroutine
+end subroutine test_pproc_dump_param
 
 
-end module
+end module test_post_processing


### PR DESCRIPTION
While adding the new xtbml part to #237, I noticed a few unused or duplicated import statements. Here, I removed them and ordered the import statements. Additionally, I made the function/subroutine definitions consistent with the remaining code. 