### PR TITLE
Avoid division by zero in new xtb-ml model

### DIFF
--- a/src/tblite/post_processing/xtb-ml/convolution.f90
+++ b/src/tblite/post_processing/xtb-ml/convolution.f90
@@ -115,6 +115,7 @@ subroutine populate_kernel(self, at, xyz)
    do k = 1, n_a
       do i = 1, nat
          do j = 1, nat
+            if (i == j) cycle
             call inv_cn(self, i, j, at, xyz, self%a(k), result)
             self%kernel(i, j, k) = result
          end do

--- a/src/tblite/post_processing/xtb-ml/convolution.f90
+++ b/src/tblite/post_processing/xtb-ml/convolution.f90
@@ -115,9 +115,12 @@ subroutine populate_kernel(self, at, xyz)
    do k = 1, n_a
       do i = 1, nat
          do j = 1, nat
-            if (i == j) cycle
-            call inv_cn(self, i, j, at, xyz, self%a(k), result)
-            self%kernel(i, j, k) = result
+            if (i /= j) then
+               call inv_cn(self, i, j, at, xyz, self%a(k), result)
+               self%kernel(i, j, k) = result
+            else
+               self%kernel(i, j, k) = 1.0_wp
+            end if
          end do
       end do
    end do

--- a/src/tblite/post_processing/xtb-ml/convolution.f90
+++ b/src/tblite/post_processing/xtb-ml/convolution.f90
@@ -149,18 +149,18 @@ subroutine inv_cn(self, a, b, at, xyz, dampening_fact, result)
 
    rco = dampening_fact*(self%rcov(at(a)) + self%rcov(at(b)))
 
-   result = 1.0_wp/exp_count(k1, r, rco)
+   result = inv_exp_count(k1, r, rco)
 
 end subroutine inv_cn
 
-!> Exponential counting function from D3
-pure elemental function exp_count(k, r, r0) result(count)
+!> Inversed exponential counting function from D3
+pure elemental function inv_exp_count(k, r, r0) result(count)
    real(wp), intent(in) :: k
    real(wp), intent(in) :: r
    real(wp), intent(in) :: r0
    real(wp) :: count
-   count = 1.0_wp/(1.0_wp + exp(-k*(r0/r - 1.0_wp)))
-end function exp_count
+   count = 1.0_wp + exp(-k*(r0/r - 1.0_wp))
+end function inv_exp_count
 
 !> Information on the container
 pure function info(self, verbosity, indent) result(str)


### PR DESCRIPTION
inv_cn routine can accept only different indexes, otherwise exp_count has division by zero.

To avoid double division (takes too much cycles even on modern processors), I replaced exp_count with inv_exp_count.

Fixes #247 