### PR TITLE
Fix CRC32 compilation with xtb: set proper sizes of integers instead default one

### DIFF
--- a/src/tblite/io/numpy/crc32.f90
+++ b/src/tblite/io/numpy/crc32.f90
@@ -34,8 +34,7 @@ module tblite_io_numpy_crc32
       module procedure crc32_hash_rdp_r1
    end interface crc32_hash
 
-   integer(i4), parameter :: crc_stub(256) = 0
-   integer(i4), parameter :: crc_table(0:255) = transfer([ &
+   integer(i4), parameter :: crc_table(0:255) = (/ &
       & int(z'00000000', kind=i4), int(z'77073096', kind=i4), int(z'ee0e612c', kind=i4), int(z'990951ba', kind=i4), &
       & int(z'076dc419', kind=i4), int(z'706af48f', kind=i4), int(z'e963a535', kind=i4), int(z'9e6495a3', kind=i4), &
       & int(z'0edb8832', kind=i4), int(z'79dcb8a4', kind=i4), int(z'e0d5e91e', kind=i4), int(z'97d2d988', kind=i4), &
@@ -99,8 +98,8 @@ module tblite_io_numpy_crc32
       & int(z'bdbdf21c', kind=i4), int(z'cabac28a', kind=i4), int(z'53b39330', kind=i4), int(z'24b4a3a6', kind=i4), &
       & int(z'bad03605', kind=i4), int(z'cdd70693', kind=i4), int(z'54de5729', kind=i4), int(z'23d967bf', kind=i4), &
       & int(z'b3667a2e', kind=i4), int(z'c4614ab8', kind=i4), int(z'5d681b02', kind=i4), int(z'2a6f2b94', kind=i4), &
-      & int(z'b40bbe37', kind=i4), int(z'c30c8ea1', kind=i4), int(z'5a05df1b', kind=i4), int(z'2d02ef8d', kind=i4)],&
-      & crc_stub)
+      & int(z'b40bbe37', kind=i4), int(z'c30c8ea1', kind=i4), int(z'5a05df1b', kind=i4), int(z'2d02ef8d', kind=i4)  &
+      /)
 
 contains
 

--- a/src/tblite/io/numpy/crc32.f90
+++ b/src/tblite/io/numpy/crc32.f90
@@ -14,8 +14,8 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
-!> @file tblite/io/numpy/load.f90
-!> Provides npy input routines
+!> @file tblite/io/numpy/crc32.f90
+!> Provides crc checksum for zip file support in npz format
 
 !> Implementation of cyclic redundancy check hashing function,
 !> used to check the integrity of data in zip files.
@@ -34,72 +34,71 @@ module tblite_io_numpy_crc32
       module procedure crc32_hash_rdp_r1
    end interface crc32_hash
 
-   integer(i4), parameter :: crc_table(0:255) = (/ &
-      & int(z'00000000', kind=i4), int(z'77073096', kind=i4), int(z'ee0e612c', kind=i4), int(z'990951ba', kind=i4), &
-      & int(z'076dc419', kind=i4), int(z'706af48f', kind=i4), int(z'e963a535', kind=i4), int(z'9e6495a3', kind=i4), &
-      & int(z'0edb8832', kind=i4), int(z'79dcb8a4', kind=i4), int(z'e0d5e91e', kind=i4), int(z'97d2d988', kind=i4), &
-      & int(z'09b64c2b', kind=i4), int(z'7eb17cbd', kind=i4), int(z'e7b82d07', kind=i4), int(z'90bf1d91', kind=i4), &
-      & int(z'1db71064', kind=i4), int(z'6ab020f2', kind=i4), int(z'f3b97148', kind=i4), int(z'84be41de', kind=i4), &
-      & int(z'1adad47d', kind=i4), int(z'6ddde4eb', kind=i4), int(z'f4d4b551', kind=i4), int(z'83d385c7', kind=i4), &
-      & int(z'136c9856', kind=i4), int(z'646ba8c0', kind=i4), int(z'fd62f97a', kind=i4), int(z'8a65c9ec', kind=i4), &
-      & int(z'14015c4f', kind=i4), int(z'63066cd9', kind=i4), int(z'fa0f3d63', kind=i4), int(z'8d080df5', kind=i4), &
-      & int(z'3b6e20c8', kind=i4), int(z'4c69105e', kind=i4), int(z'd56041e4', kind=i4), int(z'a2677172', kind=i4), &
-      & int(z'3c03e4d1', kind=i4), int(z'4b04d447', kind=i4), int(z'd20d85fd', kind=i4), int(z'a50ab56b', kind=i4), &
-      & int(z'35b5a8fa', kind=i4), int(z'42b2986c', kind=i4), int(z'dbbbc9d6', kind=i4), int(z'acbcf940', kind=i4), &
-      & int(z'32d86ce3', kind=i4), int(z'45df5c75', kind=i4), int(z'dcd60dcf', kind=i4), int(z'abd13d59', kind=i4), &
-      & int(z'26d930ac', kind=i4), int(z'51de003a', kind=i4), int(z'c8d75180', kind=i4), int(z'bfd06116', kind=i4), &
-      & int(z'21b4f4b5', kind=i4), int(z'56b3c423', kind=i4), int(z'cfba9599', kind=i4), int(z'b8bda50f', kind=i4), &
-      & int(z'2802b89e', kind=i4), int(z'5f058808', kind=i4), int(z'c60cd9b2', kind=i4), int(z'b10be924', kind=i4), &
-      & int(z'2f6f7c87', kind=i4), int(z'58684c11', kind=i4), int(z'c1611dab', kind=i4), int(z'b6662d3d', kind=i4), &
-      & int(z'76dc4190', kind=i4), int(z'01db7106', kind=i4), int(z'98d220bc', kind=i4), int(z'efd5102a', kind=i4), &
-      & int(z'71b18589', kind=i4), int(z'06b6b51f', kind=i4), int(z'9fbfe4a5', kind=i4), int(z'e8b8d433', kind=i4), &
-      & int(z'7807c9a2', kind=i4), int(z'0f00f934', kind=i4), int(z'9609a88e', kind=i4), int(z'e10e9818', kind=i4), &
-      & int(z'7f6a0dbb', kind=i4), int(z'086d3d2d', kind=i4), int(z'91646c97', kind=i4), int(z'e6635c01', kind=i4), &
-      & int(z'6b6b51f4', kind=i4), int(z'1c6c6162', kind=i4), int(z'856530d8', kind=i4), int(z'f262004e', kind=i4), &
-      & int(z'6c0695ed', kind=i4), int(z'1b01a57b', kind=i4), int(z'8208f4c1', kind=i4), int(z'f50fc457', kind=i4), &
-      & int(z'65b0d9c6', kind=i4), int(z'12b7e950', kind=i4), int(z'8bbeb8ea', kind=i4), int(z'fcb9887c', kind=i4), &
-      & int(z'62dd1ddf', kind=i4), int(z'15da2d49', kind=i4), int(z'8cd37cf3', kind=i4), int(z'fbd44c65', kind=i4), &
-      & int(z'4db26158', kind=i4), int(z'3ab551ce', kind=i4), int(z'a3bc0074', kind=i4), int(z'd4bb30e2', kind=i4), &
-      & int(z'4adfa541', kind=i4), int(z'3dd895d7', kind=i4), int(z'a4d1c46d', kind=i4), int(z'd3d6f4fb', kind=i4), &
-      & int(z'4369e96a', kind=i4), int(z'346ed9fc', kind=i4), int(z'ad678846', kind=i4), int(z'da60b8d0', kind=i4), &
-      & int(z'44042d73', kind=i4), int(z'33031de5', kind=i4), int(z'aa0a4c5f', kind=i4), int(z'dd0d7cc9', kind=i4), &
-      & int(z'5005713c', kind=i4), int(z'270241aa', kind=i4), int(z'be0b1010', kind=i4), int(z'c90c2086', kind=i4), &
-      & int(z'5768b525', kind=i4), int(z'206f85b3', kind=i4), int(z'b966d409', kind=i4), int(z'ce61e49f', kind=i4), &
-      & int(z'5edef90e', kind=i4), int(z'29d9c998', kind=i4), int(z'b0d09822', kind=i4), int(z'c7d7a8b4', kind=i4), &
-      & int(z'59b33d17', kind=i4), int(z'2eb40d81', kind=i4), int(z'b7bd5c3b', kind=i4), int(z'c0ba6cad', kind=i4), &
-      & int(z'edb88320', kind=i4), int(z'9abfb3b6', kind=i4), int(z'03b6e20c', kind=i4), int(z'74b1d29a', kind=i4), &
-      & int(z'ead54739', kind=i4), int(z'9dd277af', kind=i4), int(z'04db2615', kind=i4), int(z'73dc1683', kind=i4), &
-      & int(z'e3630b12', kind=i4), int(z'94643b84', kind=i4), int(z'0d6d6a3e', kind=i4), int(z'7a6a5aa8', kind=i4), &
-      & int(z'e40ecf0b', kind=i4), int(z'9309ff9d', kind=i4), int(z'0a00ae27', kind=i4), int(z'7d079eb1', kind=i4), &
-      & int(z'f00f9344', kind=i4), int(z'8708a3d2', kind=i4), int(z'1e01f268', kind=i4), int(z'6906c2fe', kind=i4), &
-      & int(z'f762575d', kind=i4), int(z'806567cb', kind=i4), int(z'196c3671', kind=i4), int(z'6e6b06e7', kind=i4), &
-      & int(z'fed41b76', kind=i4), int(z'89d32be0', kind=i4), int(z'10da7a5a', kind=i4), int(z'67dd4acc', kind=i4), &
-      & int(z'f9b9df6f', kind=i4), int(z'8ebeeff9', kind=i4), int(z'17b7be43', kind=i4), int(z'60b08ed5', kind=i4), &
-      & int(z'd6d6a3e8', kind=i4), int(z'a1d1937e', kind=i4), int(z'38d8c2c4', kind=i4), int(z'4fdff252', kind=i4), &
-      & int(z'd1bb67f1', kind=i4), int(z'a6bc5767', kind=i4), int(z'3fb506dd', kind=i4), int(z'48b2364b', kind=i4), &
-      & int(z'd80d2bda', kind=i4), int(z'af0a1b4c', kind=i4), int(z'36034af6', kind=i4), int(z'41047a60', kind=i4), &
-      & int(z'df60efc3', kind=i4), int(z'a867df55', kind=i4), int(z'316e8eef', kind=i4), int(z'4669be79', kind=i4), &
-      & int(z'cb61b38c', kind=i4), int(z'bc66831a', kind=i4), int(z'256fd2a0', kind=i4), int(z'5268e236', kind=i4), &
-      & int(z'cc0c7795', kind=i4), int(z'bb0b4703', kind=i4), int(z'220216b9', kind=i4), int(z'5505262f', kind=i4), &
-      & int(z'c5ba3bbe', kind=i4), int(z'b2bd0b28', kind=i4), int(z'2bb45a92', kind=i4), int(z'5cb36a04', kind=i4), &
-      & int(z'c2d7ffa7', kind=i4), int(z'b5d0cf31', kind=i4), int(z'2cd99e8b', kind=i4), int(z'5bdeae1d', kind=i4), &
-      & int(z'9b64c2b0', kind=i4), int(z'ec63f226', kind=i4), int(z'756aa39c', kind=i4), int(z'026d930a', kind=i4), &
-      & int(z'9c0906a9', kind=i4), int(z'eb0e363f', kind=i4), int(z'72076785', kind=i4), int(z'05005713', kind=i4), &
-      & int(z'95bf4a82', kind=i4), int(z'e2b87a14', kind=i4), int(z'7bb12bae', kind=i4), int(z'0cb61b38', kind=i4), &
-      & int(z'92d28e9b', kind=i4), int(z'e5d5be0d', kind=i4), int(z'7cdcefb7', kind=i4), int(z'0bdbdf21', kind=i4), &
-      & int(z'86d3d2d4', kind=i4), int(z'f1d4e242', kind=i4), int(z'68ddb3f8', kind=i4), int(z'1fda836e', kind=i4), &
-      & int(z'81be16cd', kind=i4), int(z'f6b9265b', kind=i4), int(z'6fb077e1', kind=i4), int(z'18b74777', kind=i4), &
-      & int(z'88085ae6', kind=i4), int(z'ff0f6a70', kind=i4), int(z'66063bca', kind=i4), int(z'11010b5c', kind=i4), &
-      & int(z'8f659eff', kind=i4), int(z'f862ae69', kind=i4), int(z'616bffd3', kind=i4), int(z'166ccf45', kind=i4), &
-      & int(z'a00ae278', kind=i4), int(z'd70dd2ee', kind=i4), int(z'4e048354', kind=i4), int(z'3903b3c2', kind=i4), &
-      & int(z'a7672661', kind=i4), int(z'd06016f7', kind=i4), int(z'4969474d', kind=i4), int(z'3e6e77db', kind=i4), &
-      & int(z'aed16a4a', kind=i4), int(z'd9d65adc', kind=i4), int(z'40df0b66', kind=i4), int(z'37d83bf0', kind=i4), &
-      & int(z'a9bcae53', kind=i4), int(z'debb9ec5', kind=i4), int(z'47b2cf7f', kind=i4), int(z'30b5ffe9', kind=i4), &
-      & int(z'bdbdf21c', kind=i4), int(z'cabac28a', kind=i4), int(z'53b39330', kind=i4), int(z'24b4a3a6', kind=i4), &
-      & int(z'bad03605', kind=i4), int(z'cdd70693', kind=i4), int(z'54de5729', kind=i4), int(z'23d967bf', kind=i4), &
-      & int(z'b3667a2e', kind=i4), int(z'c4614ab8', kind=i4), int(z'5d681b02', kind=i4), int(z'2a6f2b94', kind=i4), &
-      & int(z'b40bbe37', kind=i4), int(z'c30c8ea1', kind=i4), int(z'5a05df1b', kind=i4), int(z'2d02ef8d', kind=i4)  &
-      /)
+   integer(i4), parameter :: crc_table(0:255) = [ &
+      & int(z'00000000', i4), int(z'77073096', i4), int(z'ee0e612c', i4), int(z'990951ba', i4), &
+      & int(z'076dc419', i4), int(z'706af48f', i4), int(z'e963a535', i4), int(z'9e6495a3', i4), &
+      & int(z'0edb8832', i4), int(z'79dcb8a4', i4), int(z'e0d5e91e', i4), int(z'97d2d988', i4), &
+      & int(z'09b64c2b', i4), int(z'7eb17cbd', i4), int(z'e7b82d07', i4), int(z'90bf1d91', i4), &
+      & int(z'1db71064', i4), int(z'6ab020f2', i4), int(z'f3b97148', i4), int(z'84be41de', i4), &
+      & int(z'1adad47d', i4), int(z'6ddde4eb', i4), int(z'f4d4b551', i4), int(z'83d385c7', i4), &
+      & int(z'136c9856', i4), int(z'646ba8c0', i4), int(z'fd62f97a', i4), int(z'8a65c9ec', i4), &
+      & int(z'14015c4f', i4), int(z'63066cd9', i4), int(z'fa0f3d63', i4), int(z'8d080df5', i4), &
+      & int(z'3b6e20c8', i4), int(z'4c69105e', i4), int(z'd56041e4', i4), int(z'a2677172', i4), &
+      & int(z'3c03e4d1', i4), int(z'4b04d447', i4), int(z'd20d85fd', i4), int(z'a50ab56b', i4), &
+      & int(z'35b5a8fa', i4), int(z'42b2986c', i4), int(z'dbbbc9d6', i4), int(z'acbcf940', i4), &
+      & int(z'32d86ce3', i4), int(z'45df5c75', i4), int(z'dcd60dcf', i4), int(z'abd13d59', i4), &
+      & int(z'26d930ac', i4), int(z'51de003a', i4), int(z'c8d75180', i4), int(z'bfd06116', i4), &
+      & int(z'21b4f4b5', i4), int(z'56b3c423', i4), int(z'cfba9599', i4), int(z'b8bda50f', i4), &
+      & int(z'2802b89e', i4), int(z'5f058808', i4), int(z'c60cd9b2', i4), int(z'b10be924', i4), &
+      & int(z'2f6f7c87', i4), int(z'58684c11', i4), int(z'c1611dab', i4), int(z'b6662d3d', i4), &
+      & int(z'76dc4190', i4), int(z'01db7106', i4), int(z'98d220bc', i4), int(z'efd5102a', i4), &
+      & int(z'71b18589', i4), int(z'06b6b51f', i4), int(z'9fbfe4a5', i4), int(z'e8b8d433', i4), &
+      & int(z'7807c9a2', i4), int(z'0f00f934', i4), int(z'9609a88e', i4), int(z'e10e9818', i4), &
+      & int(z'7f6a0dbb', i4), int(z'086d3d2d', i4), int(z'91646c97', i4), int(z'e6635c01', i4), &
+      & int(z'6b6b51f4', i4), int(z'1c6c6162', i4), int(z'856530d8', i4), int(z'f262004e', i4), &
+      & int(z'6c0695ed', i4), int(z'1b01a57b', i4), int(z'8208f4c1', i4), int(z'f50fc457', i4), &
+      & int(z'65b0d9c6', i4), int(z'12b7e950', i4), int(z'8bbeb8ea', i4), int(z'fcb9887c', i4), &
+      & int(z'62dd1ddf', i4), int(z'15da2d49', i4), int(z'8cd37cf3', i4), int(z'fbd44c65', i4), &
+      & int(z'4db26158', i4), int(z'3ab551ce', i4), int(z'a3bc0074', i4), int(z'd4bb30e2', i4), &
+      & int(z'4adfa541', i4), int(z'3dd895d7', i4), int(z'a4d1c46d', i4), int(z'd3d6f4fb', i4), &
+      & int(z'4369e96a', i4), int(z'346ed9fc', i4), int(z'ad678846', i4), int(z'da60b8d0', i4), &
+      & int(z'44042d73', i4), int(z'33031de5', i4), int(z'aa0a4c5f', i4), int(z'dd0d7cc9', i4), &
+      & int(z'5005713c', i4), int(z'270241aa', i4), int(z'be0b1010', i4), int(z'c90c2086', i4), &
+      & int(z'5768b525', i4), int(z'206f85b3', i4), int(z'b966d409', i4), int(z'ce61e49f', i4), &
+      & int(z'5edef90e', i4), int(z'29d9c998', i4), int(z'b0d09822', i4), int(z'c7d7a8b4', i4), &
+      & int(z'59b33d17', i4), int(z'2eb40d81', i4), int(z'b7bd5c3b', i4), int(z'c0ba6cad', i4), &
+      & int(z'edb88320', i4), int(z'9abfb3b6', i4), int(z'03b6e20c', i4), int(z'74b1d29a', i4), &
+      & int(z'ead54739', i4), int(z'9dd277af', i4), int(z'04db2615', i4), int(z'73dc1683', i4), &
+      & int(z'e3630b12', i4), int(z'94643b84', i4), int(z'0d6d6a3e', i4), int(z'7a6a5aa8', i4), &
+      & int(z'e40ecf0b', i4), int(z'9309ff9d', i4), int(z'0a00ae27', i4), int(z'7d079eb1', i4), &
+      & int(z'f00f9344', i4), int(z'8708a3d2', i4), int(z'1e01f268', i4), int(z'6906c2fe', i4), &
+      & int(z'f762575d', i4), int(z'806567cb', i4), int(z'196c3671', i4), int(z'6e6b06e7', i4), &
+      & int(z'fed41b76', i4), int(z'89d32be0', i4), int(z'10da7a5a', i4), int(z'67dd4acc', i4), &
+      & int(z'f9b9df6f', i4), int(z'8ebeeff9', i4), int(z'17b7be43', i4), int(z'60b08ed5', i4), &
+      & int(z'd6d6a3e8', i4), int(z'a1d1937e', i4), int(z'38d8c2c4', i4), int(z'4fdff252', i4), &
+      & int(z'd1bb67f1', i4), int(z'a6bc5767', i4), int(z'3fb506dd', i4), int(z'48b2364b', i4), &
+      & int(z'd80d2bda', i4), int(z'af0a1b4c', i4), int(z'36034af6', i4), int(z'41047a60', i4), &
+      & int(z'df60efc3', i4), int(z'a867df55', i4), int(z'316e8eef', i4), int(z'4669be79', i4), &
+      & int(z'cb61b38c', i4), int(z'bc66831a', i4), int(z'256fd2a0', i4), int(z'5268e236', i4), &
+      & int(z'cc0c7795', i4), int(z'bb0b4703', i4), int(z'220216b9', i4), int(z'5505262f', i4), &
+      & int(z'c5ba3bbe', i4), int(z'b2bd0b28', i4), int(z'2bb45a92', i4), int(z'5cb36a04', i4), &
+      & int(z'c2d7ffa7', i4), int(z'b5d0cf31', i4), int(z'2cd99e8b', i4), int(z'5bdeae1d', i4), &
+      & int(z'9b64c2b0', i4), int(z'ec63f226', i4), int(z'756aa39c', i4), int(z'026d930a', i4), &
+      & int(z'9c0906a9', i4), int(z'eb0e363f', i4), int(z'72076785', i4), int(z'05005713', i4), &
+      & int(z'95bf4a82', i4), int(z'e2b87a14', i4), int(z'7bb12bae', i4), int(z'0cb61b38', i4), &
+      & int(z'92d28e9b', i4), int(z'e5d5be0d', i4), int(z'7cdcefb7', i4), int(z'0bdbdf21', i4), &
+      & int(z'86d3d2d4', i4), int(z'f1d4e242', i4), int(z'68ddb3f8', i4), int(z'1fda836e', i4), &
+      & int(z'81be16cd', i4), int(z'f6b9265b', i4), int(z'6fb077e1', i4), int(z'18b74777', i4), &
+      & int(z'88085ae6', i4), int(z'ff0f6a70', i4), int(z'66063bca', i4), int(z'11010b5c', i4), &
+      & int(z'8f659eff', i4), int(z'f862ae69', i4), int(z'616bffd3', i4), int(z'166ccf45', i4), &
+      & int(z'a00ae278', i4), int(z'd70dd2ee', i4), int(z'4e048354', i4), int(z'3903b3c2', i4), &
+      & int(z'a7672661', i4), int(z'd06016f7', i4), int(z'4969474d', i4), int(z'3e6e77db', i4), &
+      & int(z'aed16a4a', i4), int(z'd9d65adc', i4), int(z'40df0b66', i4), int(z'37d83bf0', i4), &
+      & int(z'a9bcae53', i4), int(z'debb9ec5', i4), int(z'47b2cf7f', i4), int(z'30b5ffe9', i4), &
+      & int(z'bdbdf21c', i4), int(z'cabac28a', i4), int(z'53b39330', i4), int(z'24b4a3a6', i4), &
+      & int(z'bad03605', i4), int(z'cdd70693', i4), int(z'54de5729', i4), int(z'23d967bf', i4), &
+      & int(z'b3667a2e', i4), int(z'c4614ab8', i4), int(z'5d681b02', i4), int(z'2a6f2b94', i4), &
+      & int(z'b40bbe37', i4), int(z'c30c8ea1', i4), int(z'5a05df1b', i4), int(z'2d02ef8d', i4)]
 
 contains
 

--- a/src/tblite/io/numpy/crc32.f90
+++ b/src/tblite/io/numpy/crc32.f90
@@ -36,70 +36,70 @@ module tblite_io_numpy_crc32
 
    integer(i4), parameter :: crc_stub(256) = 0
    integer(i4), parameter :: crc_table(0:255) = transfer([ &
-      & real(z'00000000'), real(z'77073096'), real(z'ee0e612c'), real(z'990951ba'), &
-      & real(z'076dc419'), real(z'706af48f'), real(z'e963a535'), real(z'9e6495a3'), &
-      & real(z'0edb8832'), real(z'79dcb8a4'), real(z'e0d5e91e'), real(z'97d2d988'), &
-      & real(z'09b64c2b'), real(z'7eb17cbd'), real(z'e7b82d07'), real(z'90bf1d91'), &
-      & real(z'1db71064'), real(z'6ab020f2'), real(z'f3b97148'), real(z'84be41de'), &
-      & real(z'1adad47d'), real(z'6ddde4eb'), real(z'f4d4b551'), real(z'83d385c7'), &
-      & real(z'136c9856'), real(z'646ba8c0'), real(z'fd62f97a'), real(z'8a65c9ec'), &
-      & real(z'14015c4f'), real(z'63066cd9'), real(z'fa0f3d63'), real(z'8d080df5'), &
-      & real(z'3b6e20c8'), real(z'4c69105e'), real(z'd56041e4'), real(z'a2677172'), &
-      & real(z'3c03e4d1'), real(z'4b04d447'), real(z'd20d85fd'), real(z'a50ab56b'), &
-      & real(z'35b5a8fa'), real(z'42b2986c'), real(z'dbbbc9d6'), real(z'acbcf940'), &
-      & real(z'32d86ce3'), real(z'45df5c75'), real(z'dcd60dcf'), real(z'abd13d59'), &
-      & real(z'26d930ac'), real(z'51de003a'), real(z'c8d75180'), real(z'bfd06116'), &
-      & real(z'21b4f4b5'), real(z'56b3c423'), real(z'cfba9599'), real(z'b8bda50f'), &
-      & real(z'2802b89e'), real(z'5f058808'), real(z'c60cd9b2'), real(z'b10be924'), &
-      & real(z'2f6f7c87'), real(z'58684c11'), real(z'c1611dab'), real(z'b6662d3d'), &
-      & real(z'76dc4190'), real(z'01db7106'), real(z'98d220bc'), real(z'efd5102a'), &
-      & real(z'71b18589'), real(z'06b6b51f'), real(z'9fbfe4a5'), real(z'e8b8d433'), &
-      & real(z'7807c9a2'), real(z'0f00f934'), real(z'9609a88e'), real(z'e10e9818'), &
-      & real(z'7f6a0dbb'), real(z'086d3d2d'), real(z'91646c97'), real(z'e6635c01'), &
-      & real(z'6b6b51f4'), real(z'1c6c6162'), real(z'856530d8'), real(z'f262004e'), &
-      & real(z'6c0695ed'), real(z'1b01a57b'), real(z'8208f4c1'), real(z'f50fc457'), &
-      & real(z'65b0d9c6'), real(z'12b7e950'), real(z'8bbeb8ea'), real(z'fcb9887c'), &
-      & real(z'62dd1ddf'), real(z'15da2d49'), real(z'8cd37cf3'), real(z'fbd44c65'), &
-      & real(z'4db26158'), real(z'3ab551ce'), real(z'a3bc0074'), real(z'd4bb30e2'), &
-      & real(z'4adfa541'), real(z'3dd895d7'), real(z'a4d1c46d'), real(z'd3d6f4fb'), &
-      & real(z'4369e96a'), real(z'346ed9fc'), real(z'ad678846'), real(z'da60b8d0'), &
-      & real(z'44042d73'), real(z'33031de5'), real(z'aa0a4c5f'), real(z'dd0d7cc9'), &
-      & real(z'5005713c'), real(z'270241aa'), real(z'be0b1010'), real(z'c90c2086'), &
-      & real(z'5768b525'), real(z'206f85b3'), real(z'b966d409'), real(z'ce61e49f'), &
-      & real(z'5edef90e'), real(z'29d9c998'), real(z'b0d09822'), real(z'c7d7a8b4'), &
-      & real(z'59b33d17'), real(z'2eb40d81'), real(z'b7bd5c3b'), real(z'c0ba6cad'), &
-      & real(z'edb88320'), real(z'9abfb3b6'), real(z'03b6e20c'), real(z'74b1d29a'), &
-      & real(z'ead54739'), real(z'9dd277af'), real(z'04db2615'), real(z'73dc1683'), &
-      & real(z'e3630b12'), real(z'94643b84'), real(z'0d6d6a3e'), real(z'7a6a5aa8'), &
-      & real(z'e40ecf0b'), real(z'9309ff9d'), real(z'0a00ae27'), real(z'7d079eb1'), &
-      & real(z'f00f9344'), real(z'8708a3d2'), real(z'1e01f268'), real(z'6906c2fe'), &
-      & real(z'f762575d'), real(z'806567cb'), real(z'196c3671'), real(z'6e6b06e7'), &
-      & real(z'fed41b76'), real(z'89d32be0'), real(z'10da7a5a'), real(z'67dd4acc'), &
-      & real(z'f9b9df6f'), real(z'8ebeeff9'), real(z'17b7be43'), real(z'60b08ed5'), &
-      & real(z'd6d6a3e8'), real(z'a1d1937e'), real(z'38d8c2c4'), real(z'4fdff252'), &
-      & real(z'd1bb67f1'), real(z'a6bc5767'), real(z'3fb506dd'), real(z'48b2364b'), &
-      & real(z'd80d2bda'), real(z'af0a1b4c'), real(z'36034af6'), real(z'41047a60'), &
-      & real(z'df60efc3'), real(z'a867df55'), real(z'316e8eef'), real(z'4669be79'), &
-      & real(z'cb61b38c'), real(z'bc66831a'), real(z'256fd2a0'), real(z'5268e236'), &
-      & real(z'cc0c7795'), real(z'bb0b4703'), real(z'220216b9'), real(z'5505262f'), &
-      & real(z'c5ba3bbe'), real(z'b2bd0b28'), real(z'2bb45a92'), real(z'5cb36a04'), &
-      & real(z'c2d7ffa7'), real(z'b5d0cf31'), real(z'2cd99e8b'), real(z'5bdeae1d'), &
-      & real(z'9b64c2b0'), real(z'ec63f226'), real(z'756aa39c'), real(z'026d930a'), &
-      & real(z'9c0906a9'), real(z'eb0e363f'), real(z'72076785'), real(z'05005713'), &
-      & real(z'95bf4a82'), real(z'e2b87a14'), real(z'7bb12bae'), real(z'0cb61b38'), &
-      & real(z'92d28e9b'), real(z'e5d5be0d'), real(z'7cdcefb7'), real(z'0bdbdf21'), &
-      & real(z'86d3d2d4'), real(z'f1d4e242'), real(z'68ddb3f8'), real(z'1fda836e'), &
-      & real(z'81be16cd'), real(z'f6b9265b'), real(z'6fb077e1'), real(z'18b74777'), &
-      & real(z'88085ae6'), real(z'ff0f6a70'), real(z'66063bca'), real(z'11010b5c'), &
-      & real(z'8f659eff'), real(z'f862ae69'), real(z'616bffd3'), real(z'166ccf45'), &
-      & real(z'a00ae278'), real(z'd70dd2ee'), real(z'4e048354'), real(z'3903b3c2'), &
-      & real(z'a7672661'), real(z'd06016f7'), real(z'4969474d'), real(z'3e6e77db'), &
-      & real(z'aed16a4a'), real(z'd9d65adc'), real(z'40df0b66'), real(z'37d83bf0'), &
-      & real(z'a9bcae53'), real(z'debb9ec5'), real(z'47b2cf7f'), real(z'30b5ffe9'), &
-      & real(z'bdbdf21c'), real(z'cabac28a'), real(z'53b39330'), real(z'24b4a3a6'), &
-      & real(z'bad03605'), real(z'cdd70693'), real(z'54de5729'), real(z'23d967bf'), &
-      & real(z'b3667a2e'), real(z'c4614ab8'), real(z'5d681b02'), real(z'2a6f2b94'), &
-      & real(z'b40bbe37'), real(z'c30c8ea1'), real(z'5a05df1b'), real(z'2d02ef8d')],&
+      & int(z'00000000', kind=i4), int(z'77073096', kind=i4), int(z'ee0e612c', kind=i4), int(z'990951ba', kind=i4), &
+      & int(z'076dc419', kind=i4), int(z'706af48f', kind=i4), int(z'e963a535', kind=i4), int(z'9e6495a3', kind=i4), &
+      & int(z'0edb8832', kind=i4), int(z'79dcb8a4', kind=i4), int(z'e0d5e91e', kind=i4), int(z'97d2d988', kind=i4), &
+      & int(z'09b64c2b', kind=i4), int(z'7eb17cbd', kind=i4), int(z'e7b82d07', kind=i4), int(z'90bf1d91', kind=i4), &
+      & int(z'1db71064', kind=i4), int(z'6ab020f2', kind=i4), int(z'f3b97148', kind=i4), int(z'84be41de', kind=i4), &
+      & int(z'1adad47d', kind=i4), int(z'6ddde4eb', kind=i4), int(z'f4d4b551', kind=i4), int(z'83d385c7', kind=i4), &
+      & int(z'136c9856', kind=i4), int(z'646ba8c0', kind=i4), int(z'fd62f97a', kind=i4), int(z'8a65c9ec', kind=i4), &
+      & int(z'14015c4f', kind=i4), int(z'63066cd9', kind=i4), int(z'fa0f3d63', kind=i4), int(z'8d080df5', kind=i4), &
+      & int(z'3b6e20c8', kind=i4), int(z'4c69105e', kind=i4), int(z'd56041e4', kind=i4), int(z'a2677172', kind=i4), &
+      & int(z'3c03e4d1', kind=i4), int(z'4b04d447', kind=i4), int(z'd20d85fd', kind=i4), int(z'a50ab56b', kind=i4), &
+      & int(z'35b5a8fa', kind=i4), int(z'42b2986c', kind=i4), int(z'dbbbc9d6', kind=i4), int(z'acbcf940', kind=i4), &
+      & int(z'32d86ce3', kind=i4), int(z'45df5c75', kind=i4), int(z'dcd60dcf', kind=i4), int(z'abd13d59', kind=i4), &
+      & int(z'26d930ac', kind=i4), int(z'51de003a', kind=i4), int(z'c8d75180', kind=i4), int(z'bfd06116', kind=i4), &
+      & int(z'21b4f4b5', kind=i4), int(z'56b3c423', kind=i4), int(z'cfba9599', kind=i4), int(z'b8bda50f', kind=i4), &
+      & int(z'2802b89e', kind=i4), int(z'5f058808', kind=i4), int(z'c60cd9b2', kind=i4), int(z'b10be924', kind=i4), &
+      & int(z'2f6f7c87', kind=i4), int(z'58684c11', kind=i4), int(z'c1611dab', kind=i4), int(z'b6662d3d', kind=i4), &
+      & int(z'76dc4190', kind=i4), int(z'01db7106', kind=i4), int(z'98d220bc', kind=i4), int(z'efd5102a', kind=i4), &
+      & int(z'71b18589', kind=i4), int(z'06b6b51f', kind=i4), int(z'9fbfe4a5', kind=i4), int(z'e8b8d433', kind=i4), &
+      & int(z'7807c9a2', kind=i4), int(z'0f00f934', kind=i4), int(z'9609a88e', kind=i4), int(z'e10e9818', kind=i4), &
+      & int(z'7f6a0dbb', kind=i4), int(z'086d3d2d', kind=i4), int(z'91646c97', kind=i4), int(z'e6635c01', kind=i4), &
+      & int(z'6b6b51f4', kind=i4), int(z'1c6c6162', kind=i4), int(z'856530d8', kind=i4), int(z'f262004e', kind=i4), &
+      & int(z'6c0695ed', kind=i4), int(z'1b01a57b', kind=i4), int(z'8208f4c1', kind=i4), int(z'f50fc457', kind=i4), &
+      & int(z'65b0d9c6', kind=i4), int(z'12b7e950', kind=i4), int(z'8bbeb8ea', kind=i4), int(z'fcb9887c', kind=i4), &
+      & int(z'62dd1ddf', kind=i4), int(z'15da2d49', kind=i4), int(z'8cd37cf3', kind=i4), int(z'fbd44c65', kind=i4), &
+      & int(z'4db26158', kind=i4), int(z'3ab551ce', kind=i4), int(z'a3bc0074', kind=i4), int(z'd4bb30e2', kind=i4), &
+      & int(z'4adfa541', kind=i4), int(z'3dd895d7', kind=i4), int(z'a4d1c46d', kind=i4), int(z'd3d6f4fb', kind=i4), &
+      & int(z'4369e96a', kind=i4), int(z'346ed9fc', kind=i4), int(z'ad678846', kind=i4), int(z'da60b8d0', kind=i4), &
+      & int(z'44042d73', kind=i4), int(z'33031de5', kind=i4), int(z'aa0a4c5f', kind=i4), int(z'dd0d7cc9', kind=i4), &
+      & int(z'5005713c', kind=i4), int(z'270241aa', kind=i4), int(z'be0b1010', kind=i4), int(z'c90c2086', kind=i4), &
+      & int(z'5768b525', kind=i4), int(z'206f85b3', kind=i4), int(z'b966d409', kind=i4), int(z'ce61e49f', kind=i4), &
+      & int(z'5edef90e', kind=i4), int(z'29d9c998', kind=i4), int(z'b0d09822', kind=i4), int(z'c7d7a8b4', kind=i4), &
+      & int(z'59b33d17', kind=i4), int(z'2eb40d81', kind=i4), int(z'b7bd5c3b', kind=i4), int(z'c0ba6cad', kind=i4), &
+      & int(z'edb88320', kind=i4), int(z'9abfb3b6', kind=i4), int(z'03b6e20c', kind=i4), int(z'74b1d29a', kind=i4), &
+      & int(z'ead54739', kind=i4), int(z'9dd277af', kind=i4), int(z'04db2615', kind=i4), int(z'73dc1683', kind=i4), &
+      & int(z'e3630b12', kind=i4), int(z'94643b84', kind=i4), int(z'0d6d6a3e', kind=i4), int(z'7a6a5aa8', kind=i4), &
+      & int(z'e40ecf0b', kind=i4), int(z'9309ff9d', kind=i4), int(z'0a00ae27', kind=i4), int(z'7d079eb1', kind=i4), &
+      & int(z'f00f9344', kind=i4), int(z'8708a3d2', kind=i4), int(z'1e01f268', kind=i4), int(z'6906c2fe', kind=i4), &
+      & int(z'f762575d', kind=i4), int(z'806567cb', kind=i4), int(z'196c3671', kind=i4), int(z'6e6b06e7', kind=i4), &
+      & int(z'fed41b76', kind=i4), int(z'89d32be0', kind=i4), int(z'10da7a5a', kind=i4), int(z'67dd4acc', kind=i4), &
+      & int(z'f9b9df6f', kind=i4), int(z'8ebeeff9', kind=i4), int(z'17b7be43', kind=i4), int(z'60b08ed5', kind=i4), &
+      & int(z'd6d6a3e8', kind=i4), int(z'a1d1937e', kind=i4), int(z'38d8c2c4', kind=i4), int(z'4fdff252', kind=i4), &
+      & int(z'd1bb67f1', kind=i4), int(z'a6bc5767', kind=i4), int(z'3fb506dd', kind=i4), int(z'48b2364b', kind=i4), &
+      & int(z'd80d2bda', kind=i4), int(z'af0a1b4c', kind=i4), int(z'36034af6', kind=i4), int(z'41047a60', kind=i4), &
+      & int(z'df60efc3', kind=i4), int(z'a867df55', kind=i4), int(z'316e8eef', kind=i4), int(z'4669be79', kind=i4), &
+      & int(z'cb61b38c', kind=i4), int(z'bc66831a', kind=i4), int(z'256fd2a0', kind=i4), int(z'5268e236', kind=i4), &
+      & int(z'cc0c7795', kind=i4), int(z'bb0b4703', kind=i4), int(z'220216b9', kind=i4), int(z'5505262f', kind=i4), &
+      & int(z'c5ba3bbe', kind=i4), int(z'b2bd0b28', kind=i4), int(z'2bb45a92', kind=i4), int(z'5cb36a04', kind=i4), &
+      & int(z'c2d7ffa7', kind=i4), int(z'b5d0cf31', kind=i4), int(z'2cd99e8b', kind=i4), int(z'5bdeae1d', kind=i4), &
+      & int(z'9b64c2b0', kind=i4), int(z'ec63f226', kind=i4), int(z'756aa39c', kind=i4), int(z'026d930a', kind=i4), &
+      & int(z'9c0906a9', kind=i4), int(z'eb0e363f', kind=i4), int(z'72076785', kind=i4), int(z'05005713', kind=i4), &
+      & int(z'95bf4a82', kind=i4), int(z'e2b87a14', kind=i4), int(z'7bb12bae', kind=i4), int(z'0cb61b38', kind=i4), &
+      & int(z'92d28e9b', kind=i4), int(z'e5d5be0d', kind=i4), int(z'7cdcefb7', kind=i4), int(z'0bdbdf21', kind=i4), &
+      & int(z'86d3d2d4', kind=i4), int(z'f1d4e242', kind=i4), int(z'68ddb3f8', kind=i4), int(z'1fda836e', kind=i4), &
+      & int(z'81be16cd', kind=i4), int(z'f6b9265b', kind=i4), int(z'6fb077e1', kind=i4), int(z'18b74777', kind=i4), &
+      & int(z'88085ae6', kind=i4), int(z'ff0f6a70', kind=i4), int(z'66063bca', kind=i4), int(z'11010b5c', kind=i4), &
+      & int(z'8f659eff', kind=i4), int(z'f862ae69', kind=i4), int(z'616bffd3', kind=i4), int(z'166ccf45', kind=i4), &
+      & int(z'a00ae278', kind=i4), int(z'd70dd2ee', kind=i4), int(z'4e048354', kind=i4), int(z'3903b3c2', kind=i4), &
+      & int(z'a7672661', kind=i4), int(z'd06016f7', kind=i4), int(z'4969474d', kind=i4), int(z'3e6e77db', kind=i4), &
+      & int(z'aed16a4a', kind=i4), int(z'd9d65adc', kind=i4), int(z'40df0b66', kind=i4), int(z'37d83bf0', kind=i4), &
+      & int(z'a9bcae53', kind=i4), int(z'debb9ec5', kind=i4), int(z'47b2cf7f', kind=i4), int(z'30b5ffe9', kind=i4), &
+      & int(z'bdbdf21c', kind=i4), int(z'cabac28a', kind=i4), int(z'53b39330', kind=i4), int(z'24b4a3a6', kind=i4), &
+      & int(z'bad03605', kind=i4), int(z'cdd70693', kind=i4), int(z'54de5729', kind=i4), int(z'23d967bf', kind=i4), &
+      & int(z'b3667a2e', kind=i4), int(z'c4614ab8', kind=i4), int(z'5d681b02', kind=i4), int(z'2a6f2b94', kind=i4), &
+      & int(z'b40bbe37', kind=i4), int(z'c30c8ea1', kind=i4), int(z'5a05df1b', kind=i4), int(z'2d02ef8d', kind=i4)],&
       & crc_stub)
 
 contains


### PR DESCRIPTION
Before the patch, compiling of xtb with ifx/icx was not possible since compilation of current master branch of tblite generates errors:
```
xtb-latest/build_noomp/_deps/tblite-src/src/tblite/io/numpy/crc32.f90(38): error #6366: The shapes of the array expressions do not conform.   [CRC_TABLE]
   integer(i4), parameter :: crc_table(0:255) = transfer([ &
-----------------------------^
```

The problem comes from using -fdefault-integer-8 / -fdefault-real-8 (for GNU, but anyway) flags passed during xtb compilation, and therefore sizes of arrays was incorrent with these flags. At the same time, building tblite does not gives this error since it does not use these flags.