### PR TITLE
Use npz format to store post-processing results

### DIFF
--- a/app/cli.f90
+++ b/app/cli.f90
@@ -72,6 +72,8 @@ module tblite_cli
       type(solvation_input), allocatable :: solvation
       !> Input for post processing container
       character(len=:), allocatable :: post_processing
+      !> Input for post processing container
+      character(len=:), allocatable :: post_proc_output
       !> Numerical accuracy for self-consistent iterations
       real(wp) :: accuracy = 1.0_wp
       !> Maximum number of iterations for SCF
@@ -565,6 +567,10 @@ subroutine get_run_arguments(config, list, start, error)
          write(output_unit, '(a)') help_text_run
          error stop
       end if
+   end if
+
+   if (allocated(config%post_processing) .and. .not.allocated(config%post_proc_output)) then
+      config%post_proc_output = "tblite-data.npz"
    end if
 
    if (allocated(solvent)) then

--- a/app/cli_help.f90
+++ b/app/cli_help.f90
@@ -150,6 +150,9 @@ module tblite_cli_help
       "                           Mayer-Wiberg bond orders are computed by default."//nl//&
       "                           Options: molmom (molecular multipole moments)"//nl//&
       "                           Options: xtbml (atomistic properties based on Mulliken partitioning)"//nl//& 
+      "      --post-processing-output <file>"//nl//&
+      "                           Output file for post processing results in npz format."//nl//&
+      "                           (default: tblite-data.npz)"//nl//&
       "      --grad [file]        Evaluate molecular gradient and virial"//nl//&
       "                           Results are stored in file (default: tblite.txt)"//nl//&
       "      --json [file]        Dump results as JSON output (default: tblite.json)"//nl//&

--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -266,18 +266,22 @@ subroutine run_main(config, error)
    wbo_label = "bond-orders"
    allocate(post_proc)
    call add_post_processing(post_proc, wbo_label, error)
+   if (allocated(error)) return
 
    if (config%verbosity > 2) then
       molmom_label = "molmom"
       call add_post_processing(post_proc, molmom_label, error)
+      if (allocated(error)) return
    end if
 
    if (allocated(config%post_processing)) then
       call add_post_processing(post_proc, config%post_processing, error)
+      if (allocated(error)) return
    end if
 
    if (allocated(param%post_proc)) then
       call add_post_processing(post_proc, param%post_proc)
+      if (allocated(error)) return
    end if
 
    if (config%verbosity > 0) then

--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -302,6 +302,11 @@ subroutine run_main(config, error)
       if (allocated(error)) return
    end if
 
+   if (allocated(post_proc) .and. allocated(config%post_proc_output)) then
+      call results%dict%dump(config%post_proc_output, error)
+      if (allocated(error)) return
+   end if
+
    if (config%verbosity > 2) then
       call ascii_levels(ctx%unit, config%verbosity, wfn%emo, wfn%focc, 7)
       call post_proc%dict%get_entry("molecular-dipole", dpmom)

--- a/man/tblite-run.1.adoc
+++ b/man/tblite-run.1.adoc
@@ -112,6 +112,17 @@ Supported geometry input formats are:
      Evaluates analytical gradient,
      results are stored in _file_ (default: tblite.txt)
 
+*--post-processing* _file_|_name_::
+     Add post processing methods to the calculation either by using a toml file as input
+     or by specifying the post-processing step name directly.
+     Mayer-Wiberg bond orders are computed by default.
+     - molmom (molecular multipole moments)
+     - xtbml (atomistic properties based on Mulliken partitioning)
+
+*--post-processing-output* _file_::
+     Output file for post processing results in npz format.
+     (default: tblite-data.npz)
+
 *--json* [_file_]::
      Dump results as JSON output to _file_ (default: tblite.json)
 

--- a/src/tblite/io/numpy/CMakeLists.txt
+++ b/src/tblite/io/numpy/CMakeLists.txt
@@ -25,6 +25,7 @@ list(
   "${dir}/save.f90"
   "${dir}/savez.f90"
   "${dir}/utils.f90"
+  "${dir}/zip.f90"
 )
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/tblite/io/numpy/crc32.f90
+++ b/src/tblite/io/numpy/crc32.f90
@@ -15,7 +15,7 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/io/numpy/crc32.f90
-!> Provides crc checksum for zip file support in npz format
+!> Provide crc32 hashing function
 
 !> Implementation of cyclic redundancy check hashing function,
 !> used to check the integrity of data in zip files.

--- a/src/tblite/io/numpy/meson.build
+++ b/src/tblite/io/numpy/meson.build
@@ -22,4 +22,5 @@ srcs += files(
   'save.f90',
   'savez.f90',
   'utils.f90',
+  'zip.f90',
 )

--- a/src/tblite/io/numpy/savez.f90
+++ b/src/tblite/io/numpy/savez.f90
@@ -25,6 +25,7 @@ module tblite_io_numpy_savez
       & zip_global_sig, zip_local_sig, zip_footer_sig, zip_min_version
    use tblite_io_numpy_crc32, only : crc32_hash
    use tblite_io_numpy_save, only : npy_header
+   use tblite_io_numpy_zip, only : list_zip_file, zip_file
    use tblite_output_format, only : format_string
    implicit none
    private
@@ -50,24 +51,23 @@ subroutine save_npz_i4_r1(filename, varname, array, iostat, iomsg)
    character(len=*), parameter :: vtype = type_i4
    integer, parameter :: vsize = 4
 
-   integer(i2) :: nrecs
-   integer(i4) :: global_header_offset, checksum
+   integer(i4) :: checksum, nbytes
    character(len=:), allocatable :: file_header, global_header, local_header, footer, path
-   integer(i4) :: nbytes
 
    logical :: exist
    integer :: io, stat
    character(len=:), allocatable :: msg
+   type(zip_file) :: zip
 
    path = varname // ".npy"
-   nrecs = 0_i2
-   global_header_offset = 0_i4
-   global_header = ""
+   zip%nrecs = 0_i2
+   zip%global_header_offset = 0_i4
+   zip%global_header = ""
 
    inquire(file=filename, exist=exist)
    open(newunit=io, file=filename, form="unformatted", access="stream", iostat=stat)
    if (stat == 0 .and. exist) then
-      call parse_zip_footer(io, filename, nrecs, global_header, global_header_offset, stat, msg)
+      call list_zip_file(io, filename, zip, stat, msg)
    end if
 
    if (stat == 0) then
@@ -79,10 +79,10 @@ subroutine save_npz_i4_r1(filename, varname, array, iostat, iomsg)
       nbytes = len(file_header) + size(array) * vsize
 
       local_header = get_local_header(path, checksum, nbytes)
-      global_header = global_header // get_global_header(path, local_header, global_header_offset)
-      footer = get_footer(nrecs + 1_i2, len(global_header), global_header_offset + len(local_header) + nbytes)
+      global_header = zip%global_header // get_global_header(path, local_header, zip%global_header_offset)
+      footer = get_footer(zip%nrecs + 1_i2, len(global_header), zip%global_header_offset + len(local_header) + nbytes)
 
-      write(io, pos=global_header_offset+1, iostat=stat) &
+      write(io, pos=zip%global_header_offset+1, iostat=stat) &
          & local_header, &
          & file_header, &
          & array, &
@@ -105,24 +105,23 @@ subroutine save_npz_rdp_r1(filename, varname, array, iostat, iomsg)
    character(len=*), parameter :: vtype = type_rdp
    integer, parameter :: vsize = 8
 
-   integer(i2) :: nrecs
-   integer(i4) :: global_header_offset, checksum
+   integer(i4) :: checksum, nbytes
    character(len=:), allocatable :: file_header, global_header, local_header, footer, path
-   integer(i4) :: nbytes
 
    logical :: exist
    integer :: io, stat
    character(len=:), allocatable :: msg
+   type(zip_file) :: zip
 
    path = varname // ".npy"
-   nrecs = 0_i2
-   global_header_offset = 0_i4
-   global_header = ""
+   zip%nrecs = 0_i2
+   zip%global_header_offset = 0_i4
+   zip%global_header = ""
 
    inquire(file=filename, exist=exist)
    open(newunit=io, file=filename, form="unformatted", access="stream", iostat=stat)
    if (stat == 0 .and. exist) then
-      call parse_zip_footer(io, filename, nrecs, global_header, global_header_offset, stat, msg)
+      call list_zip_file(io, filename, zip, stat, msg)
    end if
 
    if (stat == 0) then
@@ -134,10 +133,10 @@ subroutine save_npz_rdp_r1(filename, varname, array, iostat, iomsg)
       nbytes = len(file_header) + size(array) * vsize
 
       local_header = get_local_header(path, checksum, nbytes)
-      global_header = global_header // get_global_header(path, local_header, global_header_offset)
-      footer = get_footer(nrecs + 1_i2, len(global_header), global_header_offset + len(local_header) + nbytes)
+      global_header = zip%global_header // get_global_header(path, local_header, zip%global_header_offset)
+      footer = get_footer(zip%nrecs + 1_i2, len(global_header), zip%global_header_offset + len(local_header) + nbytes)
 
-      write(io, pos=global_header_offset+1, iostat=stat) &
+      write(io, pos=zip%global_header_offset+1, iostat=stat) &
          & local_header, &
          & file_header, &
          & array, &
@@ -160,24 +159,23 @@ subroutine save_npz_rdp_r2(filename, varname, array, iostat, iomsg)
    character(len=*), parameter :: vtype = type_rdp
    integer, parameter :: vsize = 8
 
-   integer(i2) :: nrecs
-   integer(i4) :: global_header_offset, checksum
+   integer(i4) :: checksum, nbytes
    character(len=:), allocatable :: file_header, global_header, local_header, footer, path
-   integer(i4) :: nbytes
 
    logical :: exist
    integer :: io, stat
    character(len=:), allocatable :: msg
+   type(zip_file) :: zip
 
    path = varname // ".npy"
-   nrecs = 0_i2
-   global_header_offset = 0_i4
-   global_header = ""
+   zip%nrecs = 0_i2
+   zip%global_header_offset = 0_i4
+   zip%global_header = ""
 
    inquire(file=filename, exist=exist)
    open(newunit=io, file=filename, form="unformatted", access="stream", iostat=stat)
    if (stat == 0 .and. exist) then
-      call parse_zip_footer(io, filename, nrecs, global_header, global_header_offset, stat, msg)
+      call list_zip_file(io, filename, zip, stat, msg)
    end if
 
    if (stat == 0) then
@@ -189,10 +187,10 @@ subroutine save_npz_rdp_r2(filename, varname, array, iostat, iomsg)
       nbytes = len(file_header) + size(array) * vsize
 
       local_header = get_local_header(path, checksum, nbytes)
-      global_header = global_header // get_global_header(path, local_header, global_header_offset)
-      footer = get_footer(nrecs + 1_i2, len(global_header), global_header_offset + len(local_header) + nbytes)
+      global_header = zip%global_header // get_global_header(path, local_header, zip%global_header_offset)
+      footer = get_footer(zip%nrecs + 1_i2, len(global_header), zip%global_header_offset + len(local_header) + nbytes)
 
-      write(io, pos=global_header_offset+1, iostat=stat) &
+      write(io, pos=zip%global_header_offset+1, iostat=stat) &
          & local_header, &
          & file_header, &
          & array, &
@@ -215,24 +213,23 @@ subroutine save_npz_rdp_r3(filename, varname, array, iostat, iomsg)
    character(len=*), parameter :: vtype = type_rdp
    integer, parameter :: vsize = 8
 
-   integer(i2) :: nrecs
-   integer(i4) :: global_header_offset, checksum
+   integer(i4) :: checksum, nbytes
    character(len=:), allocatable :: file_header, global_header, local_header, footer, path
-   integer(i4) :: nbytes
 
    logical :: exist
    integer :: io, stat
    character(len=:), allocatable :: msg
+   type(zip_file) :: zip
 
    path = varname // ".npy"
-   nrecs = 0_i2
-   global_header_offset = 0_i4
-   global_header = ""
+   zip%nrecs = 0_i2
+   zip%global_header_offset = 0_i4
+   zip%global_header = ""
 
    inquire(file=filename, exist=exist)
    open(newunit=io, file=filename, form="unformatted", access="stream", iostat=stat)
    if (stat == 0 .and. exist) then
-      call parse_zip_footer(io, filename, nrecs, global_header, global_header_offset, stat, msg)
+      call list_zip_file(io, filename, zip, stat, msg)
    end if
 
    if (stat == 0) then
@@ -244,10 +241,10 @@ subroutine save_npz_rdp_r3(filename, varname, array, iostat, iomsg)
       nbytes = len(file_header) + size(array) * vsize
 
       local_header = get_local_header(path, checksum, nbytes)
-      global_header = global_header // get_global_header(path, local_header, global_header_offset)
-      footer = get_footer(nrecs + 1_i2, len(global_header), global_header_offset + len(local_header) + nbytes)
+      global_header = zip%global_header // get_global_header(path, local_header, zip%global_header_offset)
+      footer = get_footer(zip%nrecs + 1_i2, len(global_header), zip%global_header_offset + len(local_header) + nbytes)
 
-      write(io, pos=global_header_offset+1, iostat=stat) &
+      write(io, pos=zip%global_header_offset+1, iostat=stat) &
          & local_header, &
          & file_header, &
          & array, &
@@ -338,146 +335,6 @@ pure function get_footer(nrecs, global_header_size, global_header_offset) result
    footer(21:22) = comment_len
 
 end function get_footer
-
-subroutine parse_zip_footer(io, filename, nrecs, global_header, global_header_offset, stat, msg)
-   integer, intent(in) :: io
-   character(len=*), intent(in) :: filename
-   integer(i2), intent(out) :: nrecs
-   character(len=:), allocatable, intent(out) :: global_header
-   integer(i4), intent(out) :: global_header_offset
-   integer, intent(out) :: stat
-   character(len=:), allocatable :: msg
-
-   integer(i2) :: path_size, extra_field_size, comment_size
-   integer(i2) :: disk_no, disk_start, nrecs_on_disk
-   integer(i4) :: nbytes_compressed, global_header_size
-   character(len=512) :: errmsg
-   integer :: res, length, pos
-   integer(i4) :: header_sig
-   character(len=:), allocatable :: path
-
-   stat = 0
-   pos = 1
-   read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
-   do while(stat == 0 .and. is_local_header(header_sig))
-
-      if (stat == 0) &
-         read(io, pos=pos+18, iostat=stat, iomsg=errmsg) nbytes_compressed
-      if (stat == 0) &
-         read(io, pos=pos+26, iostat=stat, iomsg=errmsg) path_size
-      if (stat == 0) &
-         read(io, pos=pos+28, iostat=stat, iomsg=errmsg) extra_field_size
-
-      if (stat == 0) then
-         if (allocated(path)) deallocate(path)
-         allocate(character(len=path_size) :: path, stat=stat)
-      end if
-      if (stat == 0) &
-         read(io, pos=pos+30, iostat=stat, iomsg=errmsg) path
-
-      pos = pos + 30 + path_size + extra_field_size + nbytes_compressed
-      read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
-   end do
-   if (stat /= 0) then
-      msg = "Failed to read local header block for '"//filename//"'"
-      if (len_trim(errmsg) > 0) &
-         msg = msg // " ("//trim(errmsg)//")"
-      return
-   end if
-
-   if (.not.is_global_header(header_sig)) then
-      stat = 400
-      msg = "Expected global header signature for '"//filename//"' got "// &
-         & format_string(header_sig, '(z0.8)')
-      return
-   end if
-
-   ! global_header_offset = pos - 1
-   do while(stat == 0 .and. is_global_header(header_sig))
-
-      if (stat == 0) &
-         read(io, pos=pos+28, iostat=stat, iomsg=errmsg) path_size
-      if (stat == 0) &
-         read(io, pos=pos+30, iostat=stat, iomsg=errmsg) extra_field_size
-      if (stat == 0) &
-         read(io, pos=pos+32, iostat=stat, iomsg=errmsg) comment_size
-
-      if (stat == 0) then
-         if (allocated(path)) deallocate(path)
-         allocate(character(len=path_size) :: path, stat=stat)
-      end if
-      if (stat == 0) &
-         read(io, pos=pos+46, iostat=stat, iomsg=errmsg) path
-
-      pos = pos + 46 + path_size + extra_field_size + comment_size
-      read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
-   end do
-   if (stat /= 0) then
-      msg = "Failed to read global header block for '"//filename//"'"
-      if (len_trim(errmsg) > 0) &
-         msg = msg // " ("//trim(errmsg)//")"
-      return
-   end if
-   if (.not.is_footer_header(header_sig)) then
-      stat = 401
-      msg = "Expected footer signature for '"//filename//"' got "// &
-         & format_string(header_sig, '(z0.8)')
-      return
-   end if
-   ! global_header_size = pos - global_header_offset + 1
-
-   read(io, pos=pos+4, iostat=stat, iomsg=errmsg) &
-      & disk_no, disk_start, nrecs_on_disk, nrecs, &
-      & global_header_size, global_header_offset, comment_size
-
-   if (stat == 0) &
-      allocate(character(len=global_header_size) :: global_header, stat=stat)
-   if (stat == 0) &
-      read(io, iostat=stat, pos=global_header_offset+1) global_header
-
-   if (stat /= 0) then
-      msg = "Failed to read footer for '"//filename//"'"
-      if (len_trim(errmsg) > 0) &
-         msg = msg // " ("//trim(errmsg)//")"
-      return
-   end if
-
-   if (disk_no /= 0) then
-      stat = 402
-      msg = "Cannot read zip file with disk_no != 0"
-   end if
-
-   if (disk_start /= 0) then
-      stat = 403
-      msg = "Cannot read zip file with disk_start != 0"
-   end if
-
-   if (nrecs_on_disk /= nrecs) then
-      stat = 404
-      msg = "Cannot read zip file with nrecs_on_disk != nrecs"
-   end if
-end subroutine parse_zip_footer
-
-pure function is_local_header(header_sig) result(is_local)
-   integer(i4), intent(in) :: header_sig
-   logical :: is_local
-
-   is_local = header_sig == zip_local_sig
-end function is_local_header
-
-pure function is_global_header(header_sig) result(is_global)
-   integer(i4), intent(in) :: header_sig
-   logical :: is_global
-
-   is_global = header_sig == zip_global_sig
-end function is_global_header
-
-pure function is_footer_header(header_sig) result(is_footer)
-   integer(i4), intent(in) :: header_sig
-   logical :: is_footer
-
-   is_footer = header_sig == zip_footer_sig
-end function is_footer_header
 
 !> Handle iostat and iomsg of write operation
 subroutine handle_iostat(stat, filename, iostat, iomsg)

--- a/src/tblite/io/numpy/zip.f90
+++ b/src/tblite/io/numpy/zip.f90
@@ -1,0 +1,191 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> @file tblite/io/numpy/zip.f90
+!> Provides zip implementation for numpy input/output.
+
+!> Provide routines for handling zip files
+module tblite_io_numpy_zip
+   use mctc_env, only : i2, i4
+   use tblite_io_numpy_constants, only : &
+      & zip_global_sig, zip_local_sig, zip_footer_sig, zip_min_version
+   use tblite_output_format, only : format_string
+   implicit none
+   private
+
+   public :: list_zip_file, zip_file
+
+   type :: zip_record
+      character(len=:), allocatable :: path
+   end type zip_record
+
+   type :: zip_file
+      type(zip_record), allocatable :: records(:)
+      character(len=:), allocatable :: global_header
+      integer(i4) :: global_header_offset = 0_i4
+      integer(i2) :: nrecs = 0_i2
+   end type zip_file
+
+
+contains
+
+subroutine list_zip_file(io, filename, zip, stat, msg)
+   integer, intent(in) :: io
+   character(len=*), intent(in) :: filename
+   type(zip_file), intent(out) :: zip
+   integer, intent(out) :: stat
+   character(len=:), allocatable :: msg
+
+   integer :: irec
+   integer(i2) :: path_size, extra_field_size, comment_size
+   integer(i2) :: disk_no, disk_start, nrecs_on_disk
+   integer(i4) :: nbytes_compressed, global_header_size
+   character(len=512) :: errmsg
+   integer :: res, length, pos
+   integer(i4) :: header_sig
+   character(len=:), allocatable :: path
+
+   stat = 0
+   irec = 0
+   pos = 1
+   read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
+   do while(stat == 0 .and. is_local_header(header_sig))
+      irec = irec + 1
+
+      if (stat == 0) &
+         read(io, pos=pos+18, iostat=stat, iomsg=errmsg) nbytes_compressed
+      if (stat == 0) &
+         read(io, pos=pos+26, iostat=stat, iomsg=errmsg) path_size
+      if (stat == 0) &
+         read(io, pos=pos+28, iostat=stat, iomsg=errmsg) extra_field_size
+
+      if (stat == 0) then
+         if (allocated(path)) deallocate(path)
+         allocate(character(len=path_size) :: path, stat=stat)
+      end if
+      if (stat == 0) &
+         read(io, pos=pos+30, iostat=stat, iomsg=errmsg) path
+
+      pos = pos + 30 + path_size + extra_field_size + nbytes_compressed
+      read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
+   end do
+   if (stat /= 0) then
+      msg = "Failed to read local header block for '"//filename//"'"
+      if (len_trim(errmsg) > 0) &
+         msg = msg // " ("//trim(errmsg)//")"
+      return
+   end if
+
+   if (.not.is_global_header(header_sig)) then
+      stat = 400
+      msg = "Expected global header signature for '"//filename//"' got "// &
+         & format_string(header_sig, '(z0.8)')
+      return
+   end if
+
+   allocate(zip%records(irec))
+
+   irec = 0
+   ! global_header_offset = pos - 1
+   do while(stat == 0 .and. is_global_header(header_sig))
+      irec = irec + 1
+
+      if (stat == 0) &
+         read(io, pos=pos+28, iostat=stat, iomsg=errmsg) path_size
+      if (stat == 0) &
+         read(io, pos=pos+30, iostat=stat, iomsg=errmsg) extra_field_size
+      if (stat == 0) &
+         read(io, pos=pos+32, iostat=stat, iomsg=errmsg) comment_size
+
+      if (stat == 0) then
+         if (allocated(path)) deallocate(path)
+         allocate(character(len=path_size) :: path, stat=stat)
+      end if
+      if (stat == 0) &
+         read(io, pos=pos+46, iostat=stat, iomsg=errmsg) path
+
+      zip%records(irec)%path = path
+
+      pos = pos + 46 + path_size + extra_field_size + comment_size
+      read(io, pos=pos, iostat=stat, iomsg=errmsg) header_sig
+   end do
+   if (stat /= 0) then
+      msg = "Failed to read global header block for '"//filename//"'"
+      if (len_trim(errmsg) > 0) &
+         msg = msg // " ("//trim(errmsg)//")"
+      return
+   end if
+   if (.not.is_footer_header(header_sig)) then
+      stat = 401
+      msg = "Expected footer signature for '"//filename//"' got "// &
+         & format_string(header_sig, '(z0.8)')
+      return
+   end if
+   ! global_header_size = pos - global_header_offset + 1
+
+   read(io, pos=pos+4, iostat=stat, iomsg=errmsg) &
+      & disk_no, disk_start, nrecs_on_disk, zip%nrecs, &
+      & global_header_size, zip%global_header_offset, comment_size
+
+   if (stat == 0) &
+      allocate(character(len=global_header_size) :: zip%global_header, stat=stat)
+   if (stat == 0) &
+      read(io, iostat=stat, pos=zip%global_header_offset+1) zip%global_header
+
+   if (stat /= 0) then
+      msg = "Failed to read footer for '"//filename//"'"
+      if (len_trim(errmsg) > 0) &
+         msg = msg // " ("//trim(errmsg)//")"
+      return
+   end if
+
+   if (disk_no /= 0) then
+      stat = 402
+      msg = "Cannot read zip file with disk_no != 0"
+   end if
+
+   if (disk_start /= 0) then
+      stat = 403
+      msg = "Cannot read zip file with disk_start != 0"
+   end if
+
+   if (nrecs_on_disk /= zip%nrecs) then
+      stat = 404
+      msg = "Cannot read zip file with nrecs_on_disk != nrecs"
+   end if
+end subroutine list_zip_file
+
+pure function is_local_header(header_sig) result(is_local)
+   integer(i4), intent(in) :: header_sig
+   logical :: is_local
+
+   is_local = header_sig == zip_local_sig
+end function is_local_header
+
+pure function is_global_header(header_sig) result(is_global)
+   integer(i4), intent(in) :: header_sig
+   logical :: is_global
+
+   is_global = header_sig == zip_global_sig
+end function is_global_header
+
+pure function is_footer_header(header_sig) result(is_footer)
+   integer(i4), intent(in) :: header_sig
+   logical :: is_footer
+
+   is_footer = header_sig == zip_footer_sig
+end function is_footer_header
+end module tblite_io_numpy_zip

--- a/src/tblite/post_processing/list.f90
+++ b/src/tblite/post_processing/list.f90
@@ -214,12 +214,8 @@ subroutine add_post_processing_cli(self, config, error)
          call toml_parse(table, io, t_error)
          close(io)
          if (allocated(t_error)) then
-            allocate(error)
-            call move_alloc(t_error%message, error%message)
+            call fatal_error(error, "Could not parse TOML file due to "//t_error%message)
             return
-         end if
-         if (allocated(error)) then
-            call fatal_error(error, "File name provided could not be parsed as a toml table")
          end if
          call get_value(table, "post-processing", child, requested=.false.)
          if (associated(child)) then

--- a/src/tblite/xtb/singlepoint.f90
+++ b/src/tblite/xtb/singlepoint.f90
@@ -347,7 +347,6 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
       allocate(results%dict)
       if (present(post_process)) then 
          call post_process%pack_res(mol, results)
-         if (prlevel > 1) call results%dict%dump("post_processing.toml", error)
       end if
    end if
 

--- a/test/unit/test_xtbml.f90
+++ b/test/unit/test_xtbml.f90
@@ -13,6 +13,7 @@ module test_xtbml
    use tblite_data_spin, only : get_spin_constant
    use tblite_double_dictionary, only : double_dictionary_type
    use tblite_integral_type, only : integral_type
+   use tblite_io_numpy, only : save_npz
    use tblite_param_post_processing, only : post_processing_param_list
    use tblite_param_serde, only : serde_record
    use tblite_param_xtbml_features, only : xtbml_features_record
@@ -696,41 +697,35 @@ subroutine test_orbital_energy_ref(error)
    !> Error handling
    integer,parameter :: nat = 3
    type(error_type), allocatable, intent(out) :: error
-   real(wp), parameter :: xyz(3, nat) = reshape((/0.00000,0.00000,1.0000000,&
-   &0.0000,0.00000,-1.0000000,&
-   &0.000000,0.000000,0.000000/),shape=(/3,nat/))
+   real(wp), parameter :: xyz(3, nat) = reshape([&
+      & 0.000000_wp, 0.000000_wp,  1.0000000_wp,&
+      & 0.000000_wp, 0.000000_wp, -1.0000000_wp,&
+      & 0.000000_wp, 0.000000_wp,  0.0000000_wp], shape=shape(xyz))
 
    integer, parameter :: num(nat) = (/8,8,6/)
    type(results_type) :: res, res_
    real(wp) :: energy = 0.0_wp
    real(wp), allocatable :: xtbml(:,:),xtbml_rot(:,:),xtbml_trans(:,:)
    integer :: i
-   integer :: io
 
-   open(newunit=io, status="scratch")
-   write(io, '(a)') &
-      "response_alpha = [ 0.1337835451437173, 0.1337835451437157, 1.6307951377273491 ]", &
-      "gap_alpha = [ 0.0095881103175756, 0.0095881103175756, 0.0011085237545836 ]", &
-      "chem_pot_alpha = [ -0.9622382191942670, -0.9622382191942677, -0.8758044318869692 ]", &
-      "HOAO_alpha = [ -0.9670322743530548, -0.9670322743530555, -0.8763586937642610 ]", &
-      "LUAO_alpha = [ -0.9574441640354792, -0.9574441640354798, -0.8752501700096774 ]", &
-      "response_beta = [ 1.2449917888491431, 1.2449917888491182, 0.0059865937960335 ]", &
-      "gap_beta = [ 0.0806953599842188, 0.0806953599842184, 19.4997052573882037 ]", &
-      "chem_pot_beta = [ -15.1513328627176183, -15.1513328627176254, -8.6913073970860637 ]", &
-      "HOAO_beta = [ -15.1916805427097277, -15.1916805427097348, -18.4411600257801638 ]", &
-      "LUAO_beta = [ -15.1109851827255088, -15.1109851827255159, 1.0585452316080382 ]", &
-      "ext_gap_alpha = [ 0.0054951699014186, 0.0054951699014186, 0.0067615787201293 ]", &
-      "ext_chem_pot_alpha = [ -0.9205182203755125, -0.9205182203755127, -0.9334269287974830 ]", &
-      "ext_HOAO_alpha = [ -0.9232658053262217, -0.9232658053262219, -0.9368077181575476 ]", &
-      "ext_LUAO_alpha = [ -0.9177706354248032, -0.9177706354248034, -0.9300461394374184 ]", &
-      "ext_gap_beta = [ 9.4593893126801003, 9.4593893126801003, 6.5604665198186094 ]", &
-      "ext_chem_pot_beta = [ -12.9537156502782160, -12.9537156502782196, -13.9314158798429979 ]", &
-      "ext_HOAO_beta = [ -17.6834103066182671, -17.6834103066182706, -17.2116491397523035 ]", &
-      "ext_LUAO_beta = [ -8.2240209939381650, -8.2240209939381685, -10.6511826199336923 ]", &
-      ""
-   rewind io
-   call dict_ref%load(io, error)
-   close(io)
+   call dict_ref%add_entry("response_alpha", [ 0.1337835451437173_wp, 0.1337835451437157_wp, 1.6307951377273491_wp])
+   call dict_ref%add_entry("gap_alpha", [ 0.0095881103175756_wp, 0.0095881103175756_wp, 0.0011085237545836_wp])
+   call dict_ref%add_entry("chem_pot_alpha", [ -0.9622382191942670_wp, -0.9622382191942677_wp, -0.8758044318869692_wp])
+   call dict_ref%add_entry("HOAO_alpha", [ -0.9670322743530548_wp, -0.9670322743530555_wp, -0.8763586937642610_wp])
+   call dict_ref%add_entry("LUAO_alpha", [ -0.9574441640354792_wp, -0.9574441640354798_wp, -0.8752501700096774_wp])
+   call dict_ref%add_entry("response_beta", [ 1.2449917888491431_wp, 1.2449917888491182_wp, 0.0059865937960335_wp])
+   call dict_ref%add_entry("gap_beta", [ 0.0806953599842188_wp, 0.0806953599842184_wp, 19.4997052573882037_wp])
+   call dict_ref%add_entry("chem_pot_beta", [ -15.1513328627176183_wp, -15.1513328627176254_wp, -8.6913073970860637_wp])
+   call dict_ref%add_entry("HOAO_beta", [ -15.1916805427097277_wp, -15.1916805427097348_wp, -18.4411600257801638_wp])
+   call dict_ref%add_entry("LUAO_beta", [ -15.1109851827255088_wp, -15.1109851827255159_wp, 1.0585452316080382_wp])
+   call dict_ref%add_entry("ext_gap_alpha", [ 0.0054951699014186_wp, 0.0054951699014186_wp, 0.0067615787201293_wp])
+   call dict_ref%add_entry("ext_chem_pot_alpha", [ -0.9205182203755125_wp, -0.9205182203755127_wp, -0.9334269287974830_wp])
+   call dict_ref%add_entry("ext_HOAO_alpha", [ -0.9232658053262217_wp, -0.9232658053262219_wp, -0.9368077181575476_wp])
+   call dict_ref%add_entry("ext_LUAO_alpha", [ -0.9177706354248032_wp, -0.9177706354248034_wp, -0.9300461394374184_wp])
+   call dict_ref%add_entry("ext_gap_beta", [ 9.4593893126801003_wp, 9.4593893126801003_wp, 6.5604665198186094_wp])
+   call dict_ref%add_entry("ext_chem_pot_beta", [ -12.9537156502782160_wp, -12.9537156502782196_wp, -13.9314158798429979_wp])
+   call dict_ref%add_entry("ext_HOAO_beta", [ -17.6834103066182671_wp, -17.6834103066182706_wp, -17.2116491397523035_wp])
+   call dict_ref%add_entry("ext_LUAO_beta", [ -8.2240209939381650_wp, -8.2240209939381685_wp, -10.6511826199336923_wp])
 
    call new(mol,num,xyz*aatoau,uhf=2,charge=0.0_wp)
    call new_gfn2_calculator(calc,mol, error)
@@ -1080,10 +1075,10 @@ subroutine test_energy_sum_up_gfn2(error)
 
    call res%dict%get_entry("E_tot", tmp_array)
    sum_energy = sum_energy + sum(tmp_array)
-   print'(3es21.14)', abs(sum_energy-energy)
+   ! print'(3es21.14)', abs(sum_energy-energy)
    if (abs(sum_energy-energy)  > thr) then
       call test_failed(error, "GFN2: Energy features don't add up to total energy.")
-      print'(3es21.14)', abs(sum_energy-energy)
+      ! print'(3es21.14)', abs(sum_energy-energy)
    end if
 
 
@@ -1097,10 +1092,10 @@ subroutine test_energy_sum_up_gfn2(error)
       sum_energy = sum_energy + sum(tmp_array)
       deallocate(tmp_array)
    end do
-   print'(3es21.14)', abs(sum_energy-energy)
+   ! print'(3es21.14)', abs(sum_energy-energy)
    if (abs(sum_energy-energy)  > thr) then
       call test_failed(error, "GFN2: Energy features don't add up to total energy.")
-      print'(3es21.14)', abs(sum_energy-energy)
+      ! print'(3es21.14)', abs(sum_energy-energy)
    end if
 
 end subroutine test_energy_sum_up_gfn2


### PR DESCRIPTION
- cleanup double dictionary implementation
- use npz format for serializing numerical data