### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,6 @@ jobs:
               FC="ifx"
               CC="icx"
             elif [ "${{ matrix.toolchain.compiler }}" = "intel-classic" ]; then
-              ls /opt/intel/oneapi/
               find /opt/intel/oneapi/ -name 'ifort'
               FC="ifort"
               CC="icc"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,34 +25,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest]
-        # build: [meson, cmake]
-        # build-type: [debug]
-        # compiler: [gnu]
-        # version: [12]
-        # toolchain: [none]
+        os: [ubuntu-latest, macos-latest]
+        build: [meson, cmake]
+        build-type: [debug]
+        compiler: [gnu]
+        version: [12]
+        toolchain: [none]
 
         include:
-        # - os: ubuntu-latest
-        #   build: meson
-        #   build-type: coverage
-        #   compiler: gnu
-        #   version: 10
-        #   toolchain: none
+        - os: ubuntu-latest
+          build: meson
+          build-type: coverage
+          compiler: gnu
+          version: 10
+          toolchain: none
 
-        # - os: ubuntu-latest
-        #   build: meson
-        #   build-type: debug
-        #   compiler: gnu
-        #   version: 11
-        #   toolchain: none
+        - os: ubuntu-latest
+          build: meson
+          build-type: debug
+          compiler: gnu
+          version: 11
+          toolchain: none
 
-        # - os: ubuntu-latest
-        #   build: meson
-        #   build-type: debug
-        #   compiler: gnu
-        #   version: 13
-        #   toolchain: none
+        - os: ubuntu-latest
+          build: meson
+          build-type: debug
+          compiler: gnu
+          version: 13
+          toolchain: none
 
         - os: ubuntu-latest
           build: meson
@@ -82,11 +82,11 @@ jobs:
           version: none
           toolchain: {compiler: intel, version: '2025.1', mkl_version: '2025.1'}
 
-        # - os: ubuntu-latest
-        #   build: fpm
-        #   compiler: gnu
-        #   version: 12
-        #   toolchain: none
+        - os: ubuntu-latest
+          build: fpm
+          compiler: gnu
+          version: 12
+          toolchain: none
 
         # - os: windows-latest
         #   build: meson

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,41 +25,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        build: [meson, cmake]
-        build-type: [debug]
-        compiler: [gnu]
-        version: [12]
-        toolchain: [none]
+        # os: [ubuntu-latest, macos-latest]
+        # build: [meson, cmake]
+        # build-type: [debug]
+        # compiler: [gnu]
+        # version: [12]
+        # toolchain: [none]
 
         include:
-        - os: ubuntu-latest
-          build: meson
-          build-type: coverage
-          compiler: gnu
-          version: 10
-          toolchain: none
+        # - os: ubuntu-latest
+        #   build: meson
+        #   build-type: coverage
+        #   compiler: gnu
+        #   version: 10
+        #   toolchain: none
 
-        - os: ubuntu-latest
-          build: meson
-          build-type: debug
-          compiler: gnu
-          version: 11
-          toolchain: none
+        # - os: ubuntu-latest
+        #   build: meson
+        #   build-type: debug
+        #   compiler: gnu
+        #   version: 11
+        #   toolchain: none
 
-        - os: ubuntu-latest
-          build: meson
-          build-type: debug
-          compiler: gnu
-          version: 13
-          toolchain: none
+        # - os: ubuntu-latest
+        #   build: meson
+        #   build-type: debug
+        #   compiler: gnu
+        #   version: 13
+        #   toolchain: none
 
-        - os: ubuntu-latest
-          build: meson
-          build-type: debug
-          compiler: gnu
-          version: 14
-          toolchain: none
+        # - os: ubuntu-latest
+        #   build: meson
+        #   build-type: debug
+        #   compiler: gnu
+        #   version: 14
+        #   toolchain: none
 
         - os: ubuntu-latest
           build: meson
@@ -82,11 +82,11 @@ jobs:
           version: none
           toolchain: {compiler: intel, version: '2025.1', mkl_version: '2025.1'}
 
-        - os: ubuntu-latest
-          build: fpm
-          compiler: gnu
-          version: 12
-          toolchain: none
+        # - os: ubuntu-latest
+        #   build: fpm
+        #   compiler: gnu
+        #   version: 12
+        #   toolchain: none
 
         # - os: windows-latest
         #   build: meson

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,8 @@ jobs:
               FC="ifx"
               CC="icx"
             elif [ "${{ matrix.toolchain.compiler }}" = "intel-classic" ]; then
+              ls /opt/intel/oneapi/
+              find /opt/intel/oneapi/ -name 'ifort'
               FC="ifort"
               CC="icc"
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           build-type: debug
           compiler: intel
           version: none
-          toolchain: {compiler: intel-classic, version: '2021.10', mkl_version: '2021.2.0'}
+          toolchain: {compiler: intel-classic, version: '2021.2', mkl_version: '2021.2.0'}
 
         - os: ubuntu-latest
           build: meson

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
         sudo mkdir -p /opt/intel
         sudo chown $USER /opt/intel
 
-    - name: Cache Intel install
+    - name: Cache Intel installation
       if: ${{ matrix.compiler == 'intel' }}
       id: cache-install
       uses: actions/cache@v4
@@ -175,7 +175,7 @@ jobs:
         path: /opt/intel/oneapi
         key: install-${{ matrix.compiler }}-${{ matrix.toolchain.version }}-${{ matrix.toolchain.mkl_version }}-${{ matrix.os }}
 
-    - name: Install Intel (Linux)
+    - name: Install Intel Compiler (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.compiler, 'intel') && steps.cache-install.outputs.cache-hit != 'true' }}
       uses: fortran-lang/setup-fortran@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,6 @@ jobs:
               FC="ifx"
               CC="icx"
             elif [ "${{ matrix.toolchain.compiler }}" = "intel-classic" ]; then
-              find /opt/intel/oneapi/ -name 'ifort'
               FC="ifort"
               CC="icc"
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,6 @@ jobs:
         shell: ${{ matrix.shell || 'bash' }}
 
     env:
-      FC: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
-      CC: ${{ matrix.compiler == 'intel' && 'icc' || 'gcc' }}
       GCC_V: ${{ matrix.version }}
       PYTHON_V: 3.9
 
@@ -192,6 +190,25 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh --force
         printenv >> $GITHUB_ENV
+
+    - name: Setup environment for Fortran and C compilers
+      run: |
+        if [ ! -n "$FC" ]; then
+          if [ "${{ matrix.compiler }}" = "gnu" ]; then
+            FC="gfortran"
+            CC="gcc"
+          elif [ "${{ matrix.compiler }}" = "intel" ]; then
+            if [ "${{ matrix.toolchain.compiler }}" = "intel" ]; then
+              FC="ifx"
+              CC="icx"
+            elif [ "${{ matrix.toolchain.compiler }}" = "intel-classic" ]; then
+              FC="ifort"
+              CC="icc"
+            fi
+          fi
+          echo "FC=$FC" >> $GITHUB_ENV
+          echo "CC=$CC" >> $GITHUB_ENV
+        fi
 
     - name: Install build and test dependencies
       if: ${{ ! contains(matrix.os, 'windows') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,12 @@ jobs:
         #   version: 13
         #   toolchain: none
 
-        # - os: ubuntu-latest
-        #   build: meson
-        #   build-type: debug
-        #   compiler: gnu
-        #   version: 14
-        #   toolchain: none
+        - os: ubuntu-latest
+          build: meson
+          build-type: debug
+          compiler: gnu
+          version: 14
+          toolchain: none
 
         - os: ubuntu-latest
           build: meson


### PR DESCRIPTION
After merging #255, there is several bugs in CI:
- cached ifort installation does not have an access to ifort
- ifort is chosen for all intel compilers, while some configurations should be ifx

To resolve first issue, the same versions (or close) of MKL and Intel compilers were installed and cached. Originally, `ifort` was in cache but by some reason it was not loaded with a proper path.
Second issue was fixed with introducing a new stage in CI.