### PR TITLE
Fix flicking overlap test

### DIFF
--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -1879,6 +1879,13 @@ subroutine test_overlap_diat_grad_ss_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = 1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_ss_z
 
 subroutine test_overlap_diat_grad_sp(error)
@@ -1949,6 +1956,13 @@ subroutine test_overlap_diat_grad_sp_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = 1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_sp_z
 
 subroutine test_overlap_diat_grad_pp(error)
@@ -2015,6 +2029,13 @@ subroutine test_overlap_diat_grad_pp_z(error)
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = 1e-7_wp
    vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
@@ -2090,6 +2111,13 @@ subroutine test_overlap_diat_grad_sd_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = 1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_sd_z
 
 subroutine test_overlap_diat_grad_pd(error)
@@ -2156,6 +2184,13 @@ subroutine test_overlap_diat_grad_pd_z(error)
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = 1e-7_wp
    vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
@@ -2230,6 +2265,13 @@ subroutine test_overlap_diat_grad_dd_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = -1e-7_wp
+   vec(2) = -1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_dd_z
 
 subroutine test_overlap_diat_grad_sf(error)
@@ -2296,6 +2338,13 @@ subroutine test_overlap_diat_grad_sf_z(error)
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = -1e-7_wp
+   vec(2) = 1e-7_wp
    vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
@@ -2371,6 +2420,13 @@ subroutine test_overlap_diat_grad_pf_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = -1e-7_wp
+   vec(2) = 1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_pf_z
 
 subroutine test_overlap_diat_grad_df(error)
@@ -2441,6 +2497,13 @@ subroutine test_overlap_diat_grad_df_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = 1e-7_wp
+   vec(2) = -1e-7_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
 end subroutine test_overlap_diat_grad_df_z
 
 subroutine test_overlap_diat_grad_ff(error)
@@ -2507,6 +2570,13 @@ subroutine test_overlap_diat_grad_ff_z(error)
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector nearly along the z-axis to test the ill-defined gradient
+   vec(1) = -1e-7_wp
+   vec(2) = -1e-7_wp
    vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)

--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -24,7 +24,7 @@ module test_integral_overlap
    use tblite_basis_slater, only : slater_to_gauss
    use tblite_cutoff, only : get_lattice_points
    use tblite_integral_overlap
-   
+
    implicit none
    private
 
@@ -76,8 +76,8 @@ subroutine collect_integral_overlap(testsuite)
       new_unittest("overlap-diat-grad-pf_z", test_overlap_diat_grad_pf_z), &
       new_unittest("overlap-diat-grad-df", test_overlap_diat_grad_df), &
       new_unittest("overlap-diat-grad-df_z", test_overlap_diat_grad_df_z), &
-      new_unittest("overlap-diat-grad-ff", test_overlap_diat_grad_ff), & 
-      new_unittest("overlap-diat-grad-ff_z", test_overlap_diat_grad_ff_z) & 
+      new_unittest("overlap-diat-grad-ff", test_overlap_diat_grad_ff), &
+      new_unittest("overlap-diat-grad-ff_z", test_overlap_diat_grad_ff_z) &
       ]
 
 end subroutine collect_integral_overlap
@@ -97,7 +97,7 @@ subroutine make_basis(bas, mol, ng)
    & 3, 3, 3, 3, 3, 3]
    integer, parameter :: lsh(4, 86) = reshape([&
    & 0, 0, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0, & ! 1-6
-   & 0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 2, 0,  0, 1, 0, 0,  0, 1, 2, 0, & ! 7-12 
+   & 0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 0, 0,  0, 1, 2, 0,  0, 1, 0, 0,  0, 1, 2, 0, & ! 7-12
    & 0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0, & ! 13-18
    & 0, 1, 0, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0, & ! 19-24
    & 0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 2, 0,  0, 1, 0, 0, & ! 25-30
@@ -114,7 +114,7 @@ subroutine make_basis(bas, mol, ng)
       & shape(lsh))
    integer, parameter :: pqn(4, 86) = reshape([&
    & 1, 0, 0, 0,  1, 2, 0, 0,  2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 0, 0, & ! 1-6
-   & 2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 3, 0,  3, 3, 0, 0,  3, 3, 3, 0, & ! 7-12 
+   & 2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 0, 0,  2, 2, 3, 0,  3, 3, 0, 0,  3, 3, 3, 0, & ! 7-12
    & 3, 3, 3, 0,  3, 3, 3, 0,  3, 3, 3, 0,  3, 3, 3, 0,  3, 3, 3, 0,  3, 3, 3, 0, & ! 13-18
    & 4, 4, 0, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0, & ! 19-24
    & 4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 3, 0,  4, 4, 0, 0, & ! 25-30
@@ -130,7 +130,7 @@ subroutine make_basis(bas, mol, ng)
    & 6, 6, 5, 0,  6, 6, 5, 0], &
       & shape(pqn))
    real(wp), parameter :: zeta(4, 86) = reshape([&
-   & 1.230000_wp, 0.000000_wp, 0.000000_wp, 0.000000_wp, & 
+   & 1.230000_wp, 0.000000_wp, 0.000000_wp, 0.000000_wp, &
    & 1.669667_wp, 1.500000_wp, 0.000000_wp, 0.000000_wp, & ! 2
    & 0.750060_wp, 0.557848_wp, 0.000000_wp, 0.000000_wp, &
    & 1.034720_wp, 0.949332_wp, 0.000000_wp, 0.000000_wp, &
@@ -148,7 +148,7 @@ subroutine make_basis(bas, mol, ng)
    & 1.981333_wp, 2.025643_wp, 1.702555_wp, 0.000000_wp, &
    & 2.485265_wp, 2.199650_wp, 2.476089_wp, 0.000000_wp, &
    & 2.329679_wp, 2.149419_wp, 1.950531_wp, 0.000000_wp, & ! 18
-   & 0.875961_wp, 0.631694_wp, 0.000000_wp, 0.000000_wp, & 
+   & 0.875961_wp, 0.631694_wp, 0.000000_wp, 0.000000_wp, &
    & 1.267130_wp, 0.786247_wp, 1.380000_wp, 0.000000_wp, &
    & 2.224492_wp, 1.554183_wp, 2.009535_wp, 0.000000_wp, &
    & 2.588796_wp, 0.994410_wp, 1.885617_wp, 0.000000_wp, &
@@ -1752,14 +1752,14 @@ subroutine test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
    real(wp), parameter :: step = 1.0e-6_wp
 
    r2 = sum(vec**2)
-   
+
    ! Test antisymmetry w.r.t. the exchange of the two centers
-   call overlap_grad_cgto_diat(cgtoi, cgtoj, r2, vec, 100.0_wp, & 
+   call overlap_grad_cgto_diat(cgtoi, cgtoj, r2, vec, 100.0_wp, &
    & ksig, kpi, kdel, overlap, doverlapi, overlap_diat, doverlapi_diat)
 
    vec(:) = -vec
 
-   call overlap_grad_cgto_diat(cgtoj, cgtoi, r2, vec, 100.0_wp, & 
+   call overlap_grad_cgto_diat(cgtoj, cgtoi, r2, vec, 100.0_wp, &
    & ksig, kpi, kdel, overlap, doverlapj, overlap_diat, doverlapj_diat)
 
    lp: do i = 1, 3
@@ -1792,13 +1792,13 @@ subroutine test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
    end do
 
    num: do i = 1, 3
-      do j = 1, msao(cgtoi%ang) 
+      do j = 1, msao(cgtoi%ang)
          do k = 1, msao(cgtoj%ang)
             call check(error, doverlapj(i, k, j), doverlaptmp(i, k, j), thr=thr2)
             if (allocated(error)) then
                write(*,*) "Error", doverlapj(i, k, j), doverlaptmp(i, k, j)
                exit num
-            end if 
+            end if
             call check(error, doverlapj_diat(i, k, j), doverlaptmp_diat(i, k, j), thr=thr2)
             if (allocated(error)) then
                write(*,*) "Error", doverlapj_diat(i, k, j), doverlaptmp_diat(i, k, j)
@@ -1856,7 +1856,7 @@ subroutine test_overlap_diat_grad_ss_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -1912,7 +1912,7 @@ subroutine test_overlap_diat_grad_sp_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -1968,7 +1968,7 @@ subroutine test_overlap_diat_grad_pp_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2025,7 +2025,7 @@ subroutine test_overlap_diat_grad_sd_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2081,7 +2081,7 @@ subroutine test_overlap_diat_grad_pd_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2193,7 +2193,7 @@ subroutine test_overlap_diat_grad_sf_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2228,7 +2228,7 @@ subroutine test_overlap_diat_grad_pf(error)
    ksig = 0.1_wp
    kpi = 0.2_wp
    kdel = 0.5_wp
-   
+
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
 end subroutine test_overlap_diat_grad_pf
@@ -2250,7 +2250,7 @@ subroutine test_overlap_diat_grad_pf_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2272,7 +2272,7 @@ subroutine test_overlap_diat_grad_df(error)
    real(wp) :: vec(3)
    real(wp) :: ksig, kpi, kdel
    integer :: stat
-   
+
    call slater_to_gauss(ng, 5, 2, 1.3_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 1.4_wp, cgtoj, .true., stat)
 
@@ -2300,13 +2300,13 @@ subroutine test_overlap_diat_grad_df_z(error)
    real(wp) :: vec(3)
    real(wp) :: ksig, kpi, kdel
    integer :: stat
-   
+
    call slater_to_gauss(ng, 5, 2, 1.3_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 1.4_wp, cgtoj, .true., stat)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp
@@ -2362,7 +2362,7 @@ subroutine test_overlap_diat_grad_ff_z(error)
 
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
+   vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    ksig = 0.1_wp

--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -1879,6 +1879,13 @@ subroutine test_overlap_diat_grad_ss_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = 1e-7_wp
    vec(2) = 1e-7_wp
@@ -1956,10 +1963,17 @@ subroutine test_overlap_diat_grad_sp_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = 1e-7_wp
    vec(2) = 1e-7_wp
-   vec(3) = 0.5_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2030,6 +2044,13 @@ subroutine test_overlap_diat_grad_pp_z(error)
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2111,6 +2132,13 @@ subroutine test_overlap_diat_grad_sd_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = 1e-7_wp
    vec(2) = 1e-7_wp
@@ -2188,10 +2216,17 @@ subroutine test_overlap_diat_grad_pd_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = 1e-7_wp
    vec(2) = 1e-7_wp
-   vec(3) = 0.5_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2262,6 +2297,13 @@ subroutine test_overlap_diat_grad_dd_z(error)
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2339,6 +2381,13 @@ subroutine test_overlap_diat_grad_sf_z(error)
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2420,6 +2469,13 @@ subroutine test_overlap_diat_grad_pf_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = -1e-7_wp
    vec(2) = 1e-7_wp
@@ -2497,6 +2553,13 @@ subroutine test_overlap_diat_grad_df_z(error)
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector nearly along the z-axis to test the ill-defined gradient
    vec(1) = 1e-7_wp
    vec(2) = -1e-7_wp
@@ -2571,6 +2634,13 @@ subroutine test_overlap_diat_grad_ff_z(error)
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = -0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 

--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -1858,14 +1858,14 @@ subroutine test_overlap_diat_grad_ss_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -1935,14 +1935,14 @@ subroutine test_overlap_diat_grad_sp_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2012,14 +2012,14 @@ subroutine test_overlap_diat_grad_pp_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2090,14 +2090,14 @@ subroutine test_overlap_diat_grad_sd_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
@@ -2167,14 +2167,14 @@ subroutine test_overlap_diat_grad_pd_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2244,14 +2244,14 @@ subroutine test_overlap_diat_grad_dd_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2321,14 +2321,14 @@ subroutine test_overlap_diat_grad_sf_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2399,14 +2399,14 @@ subroutine test_overlap_diat_grad_pf_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2476,14 +2476,14 @@ subroutine test_overlap_diat_grad_df_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp
@@ -2553,14 +2553,14 @@ subroutine test_overlap_diat_grad_ff_z(error)
    kpi = 0.2_wp
    kdel = 0.5_wp
 
-   ! Vector along the x-axis to test the ill-defined gradient
+   ! Vector along the x-axis
    vec(1) = 0.5_wp
    vec(2) = 0.0_wp
    vec(3) = 0.0_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
-   ! Vector along the y-axis to test the ill-defined gradient
+   ! Vector along the y-axis
    vec(1) = 0.0_wp
    vec(2) = 0.5_wp
    vec(3) = 0.0_wp

--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -1854,14 +1854,28 @@ subroutine test_overlap_diat_grad_ss_z(error)
    call slater_to_gauss(ng, 2, 0, 1.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 1, 0, 2.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -1910,14 +1924,28 @@ subroutine test_overlap_diat_grad_sp_z(error)
    call slater_to_gauss(ng, 4, 0, 1.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 3, 1, 2.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -1966,14 +1994,28 @@ subroutine test_overlap_diat_grad_pp_z(error)
    call slater_to_gauss(ng, 3, 1, 1.5_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 2, 1, 1.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2023,14 +2065,28 @@ subroutine test_overlap_diat_grad_sd_z(error)
    call slater_to_gauss(ng, 4, 0, 1.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 3, 2, 1.8_wp, cgtoj, .true., stat)
 
-   ! Vector along the z-axis to test the ill-defined gradient
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
 
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the z-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2079,14 +2135,28 @@ subroutine test_overlap_diat_grad_pd_z(error)
    call slater_to_gauss(ng, 4, 1, 1.5_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 3, 2, 1.5_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2135,14 +2205,28 @@ subroutine test_overlap_diat_grad_dd_z(error)
    call slater_to_gauss(ng, 4, 2, 1.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 3, 2, 1.3_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2191,14 +2275,28 @@ subroutine test_overlap_diat_grad_sf_z(error)
    call slater_to_gauss(ng, 5, 0, 2.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 1.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2248,14 +2346,28 @@ subroutine test_overlap_diat_grad_pf_z(error)
    call slater_to_gauss(ng, 5, 1, 1.0_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 2.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2304,14 +2416,28 @@ subroutine test_overlap_diat_grad_df_z(error)
    call slater_to_gauss(ng, 5, 2, 1.3_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 1.4_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 
@@ -2360,14 +2486,28 @@ subroutine test_overlap_diat_grad_ff_z(error)
    call slater_to_gauss(ng, 5, 3, 1.6_wp, cgtoi, .true., stat)
    call slater_to_gauss(ng, 4, 3, 1.0_wp, cgtoj, .true., stat)
 
+   ksig = 0.1_wp
+   kpi = 0.2_wp
+   kdel = 0.5_wp
+
+   ! Vector along the x-axis to test the ill-defined gradient
+   vec(1) = 0.5_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
+   ! Vector along the y-axis to test the ill-defined gradient
+   vec(1) = 0.0_wp
+   vec(2) = 0.5_wp
+   vec(3) = 0.0_wp
+
+   call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
+
    ! Vector along the z-axis to test the ill-defined gradient
    vec(1) = 0.0_wp
    vec(2) = 0.0_wp
    vec(3) = 0.5_wp
-
-   ksig = 0.1_wp
-   kpi = 0.2_wp
-   kdel = 0.5_wp
 
    call test_overlap_diat_grad_gen(vec, ksig, kpi, kdel, cgtoi, cgtoj, error)
 

--- a/test/unit/test_integral_overlap.f90
+++ b/test/unit/test_integral_overlap.f90
@@ -1511,7 +1511,8 @@ subroutine test_overlap_grad_ss(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
    r2 = sum(vec**2)
 
    call overlap_grad_cgto(cgtoi, cgtoj, r2, vec, 100.0_wp, overlap, doverlapj)
@@ -1563,7 +1564,8 @@ subroutine test_overlap_grad_pp(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
    r2 = sum(vec**2)
 
    call overlap_grad_cgto(cgtoi, cgtoj, r2, vec, 100.0_wp, overlap, doverlapj)
@@ -1623,7 +1625,8 @@ subroutine test_overlap_grad_dd(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
    r2 = sum(vec**2)
 
    call overlap_grad_cgto(cgtoi, cgtoj, r2, vec, 100.0_wp, overlap, doverlapj)
@@ -1683,7 +1686,8 @@ subroutine test_overlap_grad_ff(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
    r2 = sum(vec**2)
 
    call overlap_grad_cgto(cgtoi, cgtoj, r2, vec, 100.0_wp, overlap, doverlapj)
@@ -1824,7 +1828,8 @@ subroutine test_overlap_diat_grad_ss(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -1879,7 +1884,8 @@ subroutine test_overlap_diat_grad_sp(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -1934,7 +1940,8 @@ subroutine test_overlap_diat_grad_pp(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -1990,7 +1997,8 @@ subroutine test_overlap_diat_grad_sd(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2045,7 +2053,8 @@ subroutine test_overlap_diat_grad_pd(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2100,7 +2109,8 @@ subroutine test_overlap_diat_grad_dd(error)
 
    ! Randomly oriented vector of length 0.7
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.7_wp
+   vec = vec - 0.5_wp
+   vec = 0.7_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2126,9 +2136,9 @@ subroutine test_overlap_diat_grad_dd_z(error)
    call slater_to_gauss(ng, 3, 2, 1.3_wp, cgtoj, .true., stat)
 
    ! Vector along the z-axis to test the ill-defined gradient
-   vec(1) = -4.2738582800000008E-005_wp
-   vec(2) = 1.9619373507000001E-004_wp
-   vec(3) = -5.1529538776373203_wp
+   vec(1) = 0.0_wp
+   vec(2) = 0.0_wp
+   vec(3) = 0.5_wp
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2155,7 +2165,8 @@ subroutine test_overlap_diat_grad_sf(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2211,7 +2222,8 @@ subroutine test_overlap_diat_grad_pf(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2266,7 +2278,8 @@ subroutine test_overlap_diat_grad_df(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp
@@ -2321,10 +2334,8 @@ subroutine test_overlap_diat_grad_ff(error)
 
    ! Randomly oriented vector of length 0.5
    call random_number(vec)
-   vec = (vec - 0.5_wp)*(sum(vec**2))*0.5_wp
-   vec(1) = 0.0_wp
-   vec(2) = 0.0_wp   
-   vec(3) = 0.1_wp
+   vec = vec - 0.5_wp
+   vec = 0.5_wp * vec / sqrt(sum(vec**2))
 
    ksig = 0.1_wp
    kpi = 0.2_wp


### PR DESCRIPTION
Fixes #233

The problem comes from a bit strange expression for norming vectors to specific distance and therefore obtained vectors could be too short for enough precise numerical integration that lead to flicking overlap tests. Now, vectors will have the proper length according documented values. I have also expanded test sets.