### PR TITLE
Fix CI by excluding version 1.8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   BUILD_DIR: _build
   PIP_PACKAGES: >-
-    meson
+    meson<1.8.0 
     cmake
     ninja
     gcovr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   BUILD_DIR: _build
   PIP_PACKAGES: >-
-    meson<1.8.0 
+    "meson!=1.8.0" 
     cmake
     ninja
     gcovr

--- a/assets/ci/build-env.yaml
+++ b/assets/ci/build-env.yaml
@@ -2,7 +2,7 @@ name: devel
 channels:
   - conda-forge
 dependencies:
-  - meson
+  - 'meson<1.8.0'
   - fpm
   - cmake
   - ninja

--- a/assets/ci/build-env.yaml
+++ b/assets/ci/build-env.yaml
@@ -2,7 +2,7 @@ name: devel
 channels:
   - conda-forge
 dependencies:
-  - 'meson<1.8.0'
+  - 'meson!=1.8.0'
   - fpm
   - cmake
   - ninja

--- a/assets/ci/python-env.yaml
+++ b/assets/ci/python-env.yaml
@@ -14,4 +14,4 @@ dependencies:
   - ase
   - qcelemental
   - matplotlib-base
-  - 'meson<1.8.0'
+  - 'meson!=1.8.0'

--- a/assets/ci/python-env.yaml
+++ b/assets/ci/python-env.yaml
@@ -14,4 +14,4 @@ dependencies:
   - ase
   - qcelemental
   - matplotlib-base
-  - 'meson!=1.8.0'
+  - meson!=1.8.0

--- a/assets/ci/python-env.yaml
+++ b/assets/ci/python-env.yaml
@@ -14,4 +14,4 @@ dependencies:
   - ase
   - qcelemental
   - matplotlib-base
-  - meson
+  - 'meson<1.8.0'

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson-python", "cffi", "setuptools"]
+requires = ["meson < 1.8.0","meson-python", "cffi", "setuptools"]
 build-backend = "mesonpy"
 
 [project]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson < 1.8.0","meson-python", "cffi", "setuptools"]
+requires = ["meson != 1.8.0","meson-python", "cffi", "setuptools"]
 build-backend = "mesonpy"
 
 [project]


### PR DESCRIPTION
Meson Release 1.8.0 leads to the CI failing currently, this is should be a temporary patch until meson has been bumped to a version that allows stable compiling again.

To address this I exclude the meson version in use for the CI containers as well as setting meson explicitly as a requirement in `pyproject.toml` instead of relying on `meson-python`.