### PR TITLE
Deprecation warning for GCC 9, and adding compiler flag

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -38,6 +38,17 @@ set(
 )
 set(module-dir "${module-dir}" PARENT_SCOPE)
 
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 10.0)
+    message(
+      WARNING
+      "GNU Fortran version < 10.0 is not fully supported. Please use a newer version if you can."
+    )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-range-check")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}" PARENT_SCOPE)
+  endif()
+endif()
+
 # Set build type as CMake does not provide defaults
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -42,7 +42,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 10.0)
     message(
       WARNING
-      "GNU Fortran version < 10.0 is not fully supported. Please use a newer version if you can."
+      "tblite it not tested with GNU Fortran < 10, functionality might be impacted. The build automatically adds ‘-fno-range-check’ for compatibility. Please upgrade to a newer compiler version if possible."
     )
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-range-check")
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}" PARENT_SCOPE)

--- a/config/meson.build
+++ b/config/meson.build
@@ -29,8 +29,7 @@ if fc_id == 'gcc'
     '-Wno-maybe-uninitialized',
     language: 'fortran',
   )
-  message('GCC version: ' + fc.version())
-  if fc.version().contains('9.')
+  if fc.version().version_compare('<10')
     message('GNU Fortran version < 10.0 is not fully supported. Please use a newer version if you can.') 
     add_project_arguments(
       '-fno-range-check',

--- a/config/meson.build
+++ b/config/meson.build
@@ -30,7 +30,7 @@ if fc_id == 'gcc'
     language: 'fortran',
   )
   if fc.version().version_compare('<10')
-    message('GNU Fortran version < 10.0 is not fully supported. Please use a newer version if you can.') 
+    message('tblite it not tested with GNU Fortran < 10, functionality might be impacted. The build automatically adds ‘-fno-range-check’ for compatibility. Please upgrade to a newer compiler version if possible.') 
     add_project_arguments(
       '-fno-range-check',
       language: 'fortran',

--- a/config/meson.build
+++ b/config/meson.build
@@ -29,6 +29,14 @@ if fc_id == 'gcc'
     '-Wno-maybe-uninitialized',
     language: 'fortran',
   )
+  message('GCC version: ' + fc.version())
+  if fc.version().contains('9.')
+    message('GNU Fortran version < 10.0 is not fully supported. Please use a newer version if you can.') 
+    add_project_arguments(
+      '-fno-range-check',
+      language: 'fortran',
+    )
+  endif
 elif fc_id == 'intel' or fc_id == 'intel-llvm'
   add_project_arguments(
     '-traceback',


### PR DESCRIPTION
As addressed by #261, building under GCC 9 and its Fortran compiler fails without adding the `-fno-range-check` flag. Since GCC 9 is the default compiler for Ubuntu LTS 20.04 which is still commonly used I would add a warning and add the flag to the compilation. 

Here is my suggestion, for those also on 20.04 please check with your cmake and meson versions. 