### PR TITLE
Update solver to directly return new density matrix

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -78,14 +78,9 @@ jobs:
         os:
         - ubuntu-latest
         # macos-13
-        - macos-latest
+        # macos-latest
         # windows-latest
-        python: ['38', '39', '310', '311', '312', '313']
-        exclude:
-          - os: ubuntu-latest
-            python: '38'
-          - os: macos-latest
-            python: '38'
+        python: ['39', '310', '311', '312', '313']
         include: 
           - os: ubuntu-22.04
             python: '38'
@@ -102,7 +97,7 @@ jobs:
 
       # Install 'cibuildwheel' as the driver for building wheels
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.1
+        run: python -m pip install cibuildwheel==2.23.3
 
       # Download the source distribution from above
       - name: Download sdist

--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -303,7 +303,7 @@ subroutine run_main(config, error)
    end if
 
    if (config%verbosity > 2) then
-      call ascii_levels(ctx%unit, config%verbosity, wfn%homo, wfn%emo, wfn%focc, 7)
+      call ascii_levels(ctx%unit, config%verbosity, wfn%emo, wfn%focc, 7)
       call post_proc%dict%get_entry("molecular-dipole", dpmom)
       call post_proc%dict%get_entry("molecular-quadrupole", qpmom)
       

--- a/python/tblite/library.py
+++ b/python/tblite/library.py
@@ -332,12 +332,12 @@ def get_orbital_occupations(res) -> np.ndarray:
     """Retrieve orbital occupations from result container"""
     _norb = get_number_of_orbitals(res)
     _nspin = get_number_of_spins(res)
-    _occ = np.zeros((_nspin, _norb))
+    _occ = np.zeros((2, _norb))
     error_check(lib.tblite_get_result_orbital_occupations)(
         res, ffi.cast("double*", _occ.ctypes.data)
     )
     if _nspin == 1:
-        return np.squeeze(_occ, axis=0)
+        return np.sum(_occ, axis=0)
     return _occ
 
 

--- a/src/tblite/ceh/singlepoint.f90
+++ b/src/tblite/ceh/singlepoint.f90
@@ -32,7 +32,7 @@ module tblite_ceh_singlepoint
    & get_alpha_beta_occupation
    use tblite_wavefunction_mulliken, only: get_mulliken_shell_charges, &
    & get_mulliken_atomic_multipoles
-   use tblite_scf_iterator, only: get_density, get_qat_from_qsh
+   use tblite_scf_iterator, only: next_density, get_qat_from_qsh
    use tblite_scf, only: new_potential, potential_type 
    use tblite_container, only : container_cache
    use tblite_scf_potential, only: add_pot_to_h1
@@ -196,10 +196,10 @@ contains
 
       call timer%push("diagonalization")
       ! Solve the effective Hamiltonian
-      call ctx%new_solver(solver, calc%bas%nao)
+      call ctx%new_solver(solver, ints%overlap, wfn%nel, wfn%kt)
 
       ! Get the density matrix
-      call get_density(wfn, solver, ints, elec_entropy, error)
+      call next_density(wfn, solver, ints, elec_entropy, error)
       if (allocated(error)) then
          call ctx%set_error(error)
       end if

--- a/src/tblite/context/solver.f90
+++ b/src/tblite/context/solver.f90
@@ -19,6 +19,7 @@
 
 !> Abstract base class for an electronic solver
 module tblite_context_solver
+   use mctc_env, only : wp
    use tblite_scf_solver, only : solver_type
    implicit none
    private
@@ -36,14 +37,18 @@ module tblite_context_solver
 
    abstract interface
       !> Create new electronic solver
-      subroutine new(self, solver, ndim)
-         import :: context_solver, solver_type
+      subroutine new(self, solver, overlap, nel, kt)
+         import :: wp, context_solver, solver_type
          !> Instance of the solver factory
          class(context_solver), intent(inout) :: self
          !> New electronic solver
          class(solver_type), allocatable, intent(out) :: solver
-         !> Dimension of the eigenvalue problem
-         integer, intent(in) :: ndim
+         !> Overlap matrix
+         real(wp), intent(in) :: overlap(:, :)
+         !> Electronic temperature
+         real(wp), intent(in) :: kt
+         !> Number of electrons per spin channel
+         real(wp), intent(in) :: nel(:)
       end subroutine new
 
       !> Delete electronic solver instance
@@ -55,5 +60,6 @@ module tblite_context_solver
          class(solver_type), allocatable, intent(inout) :: solver
       end subroutine delete
    end interface
+
 
 end module tblite_context_solver

--- a/src/tblite/context/type.F90
+++ b/src/tblite/context/type.F90
@@ -24,7 +24,7 @@
 !> Calculation context for storing and communicating with the environment
 module tblite_context_type
    use iso_fortran_env, only : output_unit
-   use mctc_env, only : error_type
+   use mctc_env, only : wp, error_type
    use tblite_context_logger, only : context_logger
    use tblite_context_solver, only : context_solver
    use tblite_context_terminal, only : context_terminal
@@ -130,20 +130,24 @@ end function failed
 
 
 !> Create new electronic solver
-subroutine new_solver(self, solver, ndim)
+subroutine new_solver(self, solver, overlap, nel, kt)
    use tblite_lapack_solver, only : lapack_solver
    !> Instance of the calculation context
    class(context_type), intent(inout) :: self
    !> New electronic solver
    class(solver_type), allocatable, intent(out) :: solver
-   !> Dimension of the eigenvalue problem
-   integer, intent(in) :: ndim
+   !> Overlap matrix
+   real(wp), intent(in) :: overlap(:, :)
+   !> Number of electrons per spin channel
+   real(wp), intent(in) :: nel(:)
+   !> Electronic temperature
+   real(wp), intent(in) :: kt
 
    if (.not.allocated(self%solver)) then
       self%solver = lapack_solver()
    end if
 
-   call self%solver%new(solver, ndim)
+   call self%solver%new(solver, overlap, nel, kt)
 end subroutine new_solver
 
 

--- a/src/tblite/lapack/sygvd.f90
+++ b/src/tblite/lapack/sygvd.f90
@@ -19,9 +19,9 @@
 
 !> Wrapper to symmetric divide-and-conquer solver for general eigenvalue problems
 module tblite_lapack_sygvd
-   use mctc_env, only : sp, dp, error_type, fatal_error
+   use mctc_env, only : sp, dp, wp, error_type, fatal_error
    use tblite_output_format, only : format_string
-   use tblite_scf_solver, only : solver_type
+   use tblite_scf_diag, only : diag_solver_type
    implicit none
    private
 
@@ -69,7 +69,7 @@ module tblite_lapack_sygvd
 
 
    !> Wrapper class for solving symmetric general eigenvalue problems
-   type, public, extends(solver_type) :: sygvd_solver
+   type, public, extends(diag_solver_type) :: sygvd_solver
       private
       integer :: n = 0
       integer, allocatable :: iwork(:)
@@ -84,10 +84,14 @@ module tblite_lapack_sygvd
 
 contains
 
-subroutine new_sygvd(self, ndim)
+subroutine new_sygvd(self, overlap, nel, kt)
    type(sygvd_solver), intent(out) :: self
-   integer, intent(in) :: ndim
-   self%n = ndim
+   real(wp), intent(in) :: overlap(:, :)
+   real(wp), intent(in) :: nel(:)
+   real(wp), intent(in) :: kt
+   self%n = size(overlap, 1)
+   self%nel = nel
+   self%kt = kt
 end subroutine new_sygvd
 
 subroutine solve_sp(self, hmat, smat, eval, error)

--- a/src/tblite/lapack/sygvr.f90
+++ b/src/tblite/lapack/sygvr.f90
@@ -15,9 +15,9 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 module tblite_lapack_sygvr
-   use mctc_env, only : sp, dp, error_type, fatal_error
+   use mctc_env, only : sp, dp, wp, error_type, fatal_error
    use tblite_output_format, only : format_string
-   use tblite_scf_solver, only : solver_type
+   use tblite_scf_diag, only : diag_solver_type
    use tblite_lapack_sygst, only : wrap_sygst
    use tblite_lapack_potrf, only : wrap_potrf
    use tblite_blas_level3, only : wrap_trsm
@@ -88,7 +88,7 @@ module tblite_lapack_sygvr
    end interface lapack_syevr
 
 
-   type, public, extends(solver_type) :: sygvr_solver
+   type, public, extends(diag_solver_type) :: sygvr_solver
       private
       integer :: n = 0
       integer, allocatable :: iwork(:)
@@ -106,10 +106,14 @@ module tblite_lapack_sygvr
 
 contains
 
-subroutine new_sygvr(self, ndim)
+subroutine new_sygvr(self, overlap, nel, kt)
    type(sygvr_solver), intent(out) :: self
-   integer, intent(in) :: ndim
-   self%n = ndim
+   real(wp), intent(in) :: overlap(:, :)
+   real(wp), intent(in) :: nel(:)
+   real(wp), intent(in) :: kt
+   self%n = size(overlap, 1)
+   self%nel = nel
+   self%kt = kt
 end subroutine new_sygvr
 
 subroutine solve_sp(self, hmat, smat, eval, error)

--- a/src/tblite/post_processing/xtb-ml/density.f90
+++ b/src/tblite/post_processing/xtb-ml/density.f90
@@ -104,7 +104,7 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    character(len=20), allocatable :: tmp_labels(:)
    real(wp), allocatable :: tmp_s_array(:), tmp_p_array(:), tmp_d_array(:), tmp_array(:, :)
    real(wp) :: z(mol%nat)
-   integer :: i, mu, nspin, spin
+   integer :: i, nspin, spin
    character(len=6), allocatable :: spin_label(:)
 
    nspin = wfn%nspin

--- a/src/tblite/post_processing/xtb-ml/orbital_energy.f90
+++ b/src/tblite/post_processing/xtb-ml/orbital_energy.f90
@@ -108,7 +108,6 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    !> Cache list for storing caches of various interactions
    type(container_cache), intent(inout) :: cache_list(:)
 
-   real(wp) :: focc_(2, size(wfn%focc, dim=1))
    integer :: i, j, nspin, spin
    real(wp) :: nel_
    character(len=6), allocatable :: spin_label(:)
@@ -127,24 +126,6 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    call self%allocate(mol%nat, nspin)
    self%label = label
 
-   focc_ = 0.0_wp
-   if (wfn%nuhf > 0) then
-      do j = 1,2
-         nel_ = wfn%nel(j)
-         do i = 1, size(wfn%focc)
-            if (nel_ > 1.0_wp) then
-               focc_(j, i) = 1.0_wp
-               nel_ = nel_ - 1.0_wp
-            else
-               focc_(j, i) = nel_
-               exit
-            end if
-         end do
-      end do
-   else
-      focc_(1, :) = wfn%focc(:, 1) / 2.0_wp
-      focc_(2, :) = wfn%focc(:, 1) / 2.0_wp
-   end if
    do spin = 1, nspin
       if (wfn%nspin > 1) then
          call atomic_frontier_orbitals(wfn%focc(:, spin), wfn%emo(:, spin)*autoev, &
@@ -152,7 +133,7 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
             self%response, self%egap(:, spin), self%chempot(:, spin), self%ehoao, &
             self%eluao)
       else
-         call atomic_frontier_orbitals(focc_(spin, :), wfn%emo(:, 1)*autoev, &
+         call atomic_frontier_orbitals(wfn%focc(:, spin), wfn%emo(:, 1)*autoev, &
             calc%bas%ao2at, wfn%coeff(:, :, 1), integrals%overlap(:, :), &
             self%response, self%egap(:, spin), self%chempot(:, spin), self%ehoao, &
             self%eluao)

--- a/src/tblite/scf/CMakeLists.txt
+++ b/src/tblite/scf/CMakeLists.txt
@@ -20,6 +20,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(
   APPEND srcs
+  "${dir}/diag.f90"
   "${dir}/info.f90"
   "${dir}/iterator.f90"
   "${dir}/mixer.f90"

--- a/src/tblite/scf/diag.f90
+++ b/src/tblite/scf/diag.f90
@@ -1,0 +1,176 @@
+! This file is part of tblite.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! tblite is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! tblite is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
+
+!> @file tblite/scf/diag.f90
+!> Provides a base class for defining diagonalization based electronic solvers
+
+!> Declaration of the abstract base class for electronic solvers based on diagonalization
+module tblite_scf_diag
+   use mctc_env, only : sp, dp, wp, error_type
+   use tblite_blas, only : gemm
+   use tblite_scf_solver, only : solver_type
+   use tblite_wavefunction_fermi, only : get_fermi_filling
+   implicit none
+   private
+
+   !> Abstract base class for electronic solvers
+   type, public, abstract, extends(solver_type) :: diag_solver_type
+   contains
+      generic :: solve => solve_sp, solve_dp
+      procedure(solve_sp), deferred :: solve_sp
+      procedure(solve_dp), deferred :: solve_dp
+      procedure :: get_density
+      procedure :: get_wdensity
+      procedure :: delete
+   end type diag_solver_type
+
+   abstract interface
+      subroutine solve_sp(self, hmat, smat, eval, error)
+         import :: diag_solver_type, error_type, sp
+         class(diag_solver_type), intent(inout) :: self
+         real(sp), contiguous, intent(inout) :: hmat(:, :)
+         real(sp), contiguous, intent(in) :: smat(:, :)
+         real(sp), contiguous, intent(inout) :: eval(:)
+         type(error_type), allocatable, intent(out) :: error
+      end subroutine solve_sp
+      subroutine solve_dp(self, hmat, smat, eval, error)
+         import :: diag_solver_type, error_type, dp
+         class(diag_solver_type), intent(inout) :: self
+         real(dp), contiguous, intent(inout) :: hmat(:, :)
+         real(dp), contiguous, intent(in) :: smat(:, :)
+         real(dp), contiguous, intent(inout) :: eval(:)
+         type(error_type), allocatable, intent(out) :: error
+      end subroutine solve_dp
+   end interface
+
+
+contains
+
+subroutine get_density(self, hmat, smat, eval, focc, density, error)
+   !> Solver for the general eigenvalue problem
+   class(diag_solver_type), intent(inout) :: self
+   !> Overlap matrix
+   real(wp), contiguous, intent(in) :: smat(:, :)
+   !> Hamiltonian matrix, contains eigenvectors on output
+   real(wp), contiguous, intent(inout) :: hmat(:, :, :)
+   !> Eigenvalues
+   real(wp), contiguous, intent(inout) :: eval(:, :)
+   !> Occupation numbers
+   real(wp), contiguous, intent(inout) :: focc(:, :)
+   !> Density matrix
+   real(wp), contiguous, intent(inout) :: density(:, :, :)
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   real(wp) :: e_fermi
+   integer :: nspin, spin, homo
+
+   nspin = min(size(eval, 2), size(hmat, 3), size(density, 3))
+
+   select case(nspin)
+   case default
+      call self%solve(hmat(:, :, 1), smat, eval(:, 1), error)
+      if (allocated(error)) return
+
+      focc(:, :) = 0.0_wp
+      do spin = 1, 2
+         call get_fermi_filling(self%nel(spin), self%kt, eval(:, 1), &
+            & homo, focc(:, spin), e_fermi)
+      end do
+
+      focc(:, 1) = focc(:, 1) + focc(:, 2)
+      call get_density_matrix(focc(:, 1), hmat(:, :, 1), density(:, :, 1))
+      focc(:, 1) = focc(:, 1) - focc(:, 2)
+   case(2)
+      hmat(:, :, :) = 2*hmat
+      do spin = 1, 2
+         call self%solve(hmat(:, :, spin), smat, eval(:, spin), error)
+         if (allocated(error)) return
+
+         call get_fermi_filling(self%nel(spin), self%kt, eval(:, spin), &
+            & homo, focc(:, spin), e_fermi)
+         call get_density_matrix(focc(:, spin), hmat(:, :, spin), density(:, :, spin))
+      end do
+   end select
+end subroutine get_density
+
+subroutine get_wdensity(self, hmat, smat, eval, focc, density, error)
+   !> Solver for the general eigenvalue problem
+   class(diag_solver_type), intent(inout) :: self
+   !> Overlap matrix
+   real(wp), contiguous, intent(in) :: smat(:, :)
+   !> Hamiltonian matrix containing eigenvectors from SCF
+   real(wp), contiguous, intent(inout) :: hmat(:, :, :)
+   !> Eigenvalues
+   real(wp), contiguous, intent(inout) :: eval(:, :)
+   !> Occupation numbers
+   real(wp), contiguous, intent(inout) :: focc(:, :)
+   !> Density matrix
+   real(wp), contiguous, intent(inout) :: density(:, :, :)
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   integer :: spin, nspin
+   real(wp), allocatable :: tmp(:)
+
+   nspin = min(size(eval, 2), size(hmat, 3), size(density, 3))
+
+   if (nspin == 1 .and. size(focc, 2) == 2) then
+      focc(:, 1) = focc(:, 1) + focc(:, 2)
+   end if
+
+   do spin = 1, nspin
+      tmp = focc(:, spin) * eval(:, spin)
+      call get_density_matrix(tmp, hmat(:, :, spin), density(:, :, spin))
+   end do
+
+   if (nspin == 1 .and. size(focc, 2) == 2) then
+      focc(:, 1) = focc(:, 1) - focc(:, 2)
+   end if
+end subroutine get_wdensity
+
+!> Get the density matrix from the coefficients and occupation numbers
+subroutine get_density_matrix(focc, coeff, pmat)
+   !> Occupation numbers
+   real(wp), intent(in) :: focc(:)
+   !> Coefficients of the wavefunction
+   real(wp), contiguous, intent(in) :: coeff(:, :)
+   !> Density matrix to be computed
+   real(wp), contiguous, intent(out) :: pmat(:, :)
+
+   real(wp), allocatable :: scratch(:, :)
+   integer :: iao, jao
+
+   allocate(scratch(size(pmat, 1), size(pmat, 2)))
+   !$omp parallel do collapse(2) default(none) schedule(runtime) &
+   !$omp shared(scratch, coeff, focc, pmat) private(iao, jao)
+   do iao = 1, size(pmat, 1)
+      do jao = 1, size(pmat, 2)
+         scratch(jao, iao) = coeff(jao, iao) * focc(iao)
+      end do
+   end do
+   call gemm(scratch, coeff, pmat, transb='t')
+end subroutine get_density_matrix
+
+!> Delete the solver instance
+subroutine delete(self)
+   !> Solver for the general eigenvalue problem
+   class(diag_solver_type), intent(inout) :: self
+
+   ! No specific resources to free in this base class
+end subroutine delete
+
+end module tblite_scf_diag

--- a/src/tblite/scf/iterator.f90
+++ b/src/tblite/scf/iterator.f90
@@ -25,7 +25,7 @@ module tblite_scf_iterator
    use tblite_container, only : container_cache, container_list
    use tblite_disp, only : dispersion_type
    use tblite_integral_type, only : integral_type
-   use tblite_wavefunction_type, only : wavefunction_type, get_density_matrix
+   use tblite_wavefunction_type, only : wavefunction_type
    use tblite_wavefunction_fermi, only : get_fermi_filling
    use tblite_wavefunction_mulliken, only : get_mulliken_shell_charges, &
       & get_mulliken_atomic_multipoles
@@ -38,7 +38,7 @@ module tblite_scf_iterator
    private
 
    public :: next_scf, get_mixer_dimension, get_electronic_energy, reduce
-   public :: get_density, get_qat_from_qsh
+   public :: next_density, get_qat_from_qsh
 
 contains
 
@@ -108,7 +108,7 @@ subroutine next_scf(iscf, mol, bas, wfn, solver, mixer, info, coulomb, dispersio
 
    call set_mixer(mixer, wfn, info)
 
-   call get_density(wfn, solver, ints, ts, error)
+   call next_density(wfn, solver, ints, ts, error)
    if (allocated(error)) return
 
    call get_mulliken_shell_charges(bas, ints%overlap, wfn%density, wfn%n0sh, &
@@ -291,7 +291,7 @@ subroutine get_mixer(mixer, bas, wfn, info)
 end subroutine get_mixer
 
 
-subroutine get_density(wfn, solver, ints, ts, error)
+subroutine next_density(wfn, solver, ints, ts, error)
    !> Tight-binding wavefunction data
    type(wavefunction_type), intent(inout) :: wfn
    !> Solver for the general eigenvalue problem
@@ -307,37 +307,12 @@ subroutine get_density(wfn, solver, ints, ts, error)
    real(wp), allocatable :: focc(:)
    integer :: spin
 
-   select case(wfn%nspin)
-   case default
-      call solver%solve(wfn%coeff(:, :, 1), ints%overlap, wfn%emo(:, 1), error)
-      if (allocated(error)) return
-
-      allocate(focc(size(wfn%focc, 1)))
-      wfn%focc(:, :) = 0.0_wp
-      do spin = 1, 2
-         call get_fermi_filling(wfn%nel(spin), wfn%kt, wfn%emo(:, 1), &
-            & wfn%homo(spin), focc, e_fermi)
-         call get_electronic_entropy(focc, wfn%kt, stmp(spin))
-         wfn%focc(:, 1) = wfn%focc(:, 1) + focc
-      end do
-      ts = sum(stmp)
-
-      call get_density_matrix(wfn%focc(:, 1), wfn%coeff(:, :, 1), wfn%density(:, :, 1))
-   case(2)
-      wfn%coeff = 2*wfn%coeff
-      do spin = 1, 2
-         call solver%solve(wfn%coeff(:, :, spin), ints%overlap, wfn%emo(:, spin), error)
-         if (allocated(error)) return
-
-         call get_fermi_filling(wfn%nel(spin), wfn%kt, wfn%emo(:, spin), &
-            & wfn%homo(spin), wfn%focc(:, spin), e_fermi)
-         call get_electronic_entropy(wfn%focc(:, spin), wfn%kt, stmp(spin))
-         call get_density_matrix(wfn%focc(:, spin), wfn%coeff(:, :, spin), &
-            & wfn%density(:, :, spin))
-      end do
-      ts = sum(stmp)
-   end select
-end subroutine get_density
+   call solver%get_density(wfn%coeff, ints%overlap, wfn%emo, wfn%focc, wfn%density, error)
+   do spin = 1, 2
+      call get_electronic_entropy(wfn%focc(:, spin), wfn%kt, stmp(spin))
+   end do
+   ts = sum(stmp)
+end subroutine next_density
 
 subroutine get_electronic_entropy(occ, kt, s)
    real(wp), intent(in) :: occ(:)

--- a/src/tblite/scf/meson.build
+++ b/src/tblite/scf/meson.build
@@ -17,6 +17,7 @@
 subdir('mixer')
 
 srcs += files(
+  'diag.f90',
   'info.f90',
   'iterator.f90',
   'mixer.f90',

--- a/src/tblite/scf/solver.f90
+++ b/src/tblite/scf/solver.f90
@@ -19,36 +19,47 @@
 
 !> Declaration of the abstract base class for electronic solvers
 module tblite_scf_solver
-   use mctc_env, only : sp, dp, error_type
+   use mctc_env, only : sp, dp, wp, error_type
+   use tblite_blas, only : gemm
    implicit none
    private
 
    !> Abstract base class for electronic solvers
    type, public, abstract :: solver_type
+      !> Electronic temperature
+      real(wp) :: kt
+      !> Number of electrons per spin channel
+      real(wp), allocatable :: nel(:)
    contains
-      generic :: solve => solve_sp, solve_dp
-      procedure(solve_sp), deferred :: solve_sp
-      procedure(solve_dp), deferred :: solve_dp
+      procedure(get_density), deferred :: get_density
+      procedure(get_density), deferred :: get_wdensity
+      procedure(delete), deferred :: delete
    end type solver_type
 
    abstract interface
-      subroutine solve_sp(self, hmat, smat, eval, error)
-         import :: solver_type, error_type, sp
+      subroutine get_density(self, hmat, smat, eval, focc, density, error)
+         import :: wp, solver_type, error_type
+         !> Solver for the general eigenvalue problem
          class(solver_type), intent(inout) :: self
-         real(sp), contiguous, intent(inout) :: hmat(:, :)
-         real(sp), contiguous, intent(in) :: smat(:, :)
-         real(sp), contiguous, intent(inout) :: eval(:)
+         !> Overlap matrix
+         real(wp), contiguous, intent(in) :: smat(:, :)
+         !> Hamiltonian matrix, can contains eigenvectors on output
+         real(wp), contiguous, intent(inout) :: hmat(:, :, :)
+         !> Eigenvalues
+         real(wp), contiguous, intent(inout) :: eval(:, :)
+         !> Occupation numbers
+         real(wp), contiguous, intent(inout) :: focc(:, :)
+         !> Density matrix
+         real(wp), contiguous, intent(inout) :: density(:, :, :)
+         !> Error handling
          type(error_type), allocatable, intent(out) :: error
-      end subroutine solve_sp
-      subroutine solve_dp(self, hmat, smat, eval, error)
-         import :: solver_type, error_type, dp
-         class(solver_type), intent(inout) :: self
-         real(dp), contiguous, intent(inout) :: hmat(:, :)
-         real(dp), contiguous, intent(in) :: smat(:, :)
-         real(dp), contiguous, intent(inout) :: eval(:)
-         type(error_type), allocatable, intent(out) :: error
-      end subroutine solve_dp
-   end interface
+      end subroutine get_density
 
+      subroutine delete(self)
+         import :: solver_type
+         !> Solver for the general eigenvalue problem
+         class(solver_type), intent(inout) :: self
+      end subroutine delete
+   end interface
 
 end module tblite_scf_solver

--- a/src/tblite/wavefunction/restart.f90
+++ b/src/tblite/wavefunction/restart.f90
@@ -56,9 +56,6 @@ subroutine load_wavefunction(wfn, filename, error, nat, nsh, nao, nspin)
    call load_npz(filename, prefix//"kt", kt, stat, msg)
 
    if (stat == 0) then
-      call load_npz(filename, prefix//"homo", wfn%homo, stat, msg)
-   end if
-   if (stat == 0) then
       call load_npz(filename, prefix//"nel", wfn%nel, stat, msg)
    end if
    if (stat == 0) then
@@ -128,8 +125,7 @@ subroutine load_wavefunction(wfn, filename, error, nat, nsh, nao, nspin)
 
    nspin_sizes = [size(wfn%density, 3), size(wfn%coeff, 3), size(wfn%emo, 2), size(wfn%focc, 2)]
    if (present(nspin)) nspin_sizes = [nspin, nspin_sizes]
-   if (any(nspin_sizes(1) /= nspin_sizes) .or. (size(wfn%nel) /= size(wfn%homo) &
-      & .and. all(size(wfn%nel) /= [2, nspin_sizes(1)]))) then
+   if (any(nspin_sizes(1) /= nspin_sizes) .or. (all(size(wfn%nel) /= [2, nspin_sizes(1)]))) then
       call fatal_error(error, "Dimension mismatch in '"//filename//&
          & "' for number of spin channels")
       return
@@ -176,9 +172,6 @@ subroutine save_wavefunction(wfn, filename, error)
 
    call save_npz(filename, prefix//"kt", [wfn%kt], stat, msg)
 
-   if (stat == 0) then
-      call save_npz(filename, prefix//"homo", wfn%homo, stat, msg)
-   end if
    if (stat == 0) then
       call save_npz(filename, prefix//"nel", wfn%nel, stat, msg)
    end if

--- a/src/tblite/wavefunction/type.f90
+++ b/src/tblite/wavefunction/type.f90
@@ -37,8 +37,6 @@ module tblite_wavefunction_type
       real(wp) :: nuhf = 0.0_wp
       !> Number of spin channels
       integer :: nspin = 1
-      !> Index of the highest occupied molecular orbitals
-      integer, allocatable :: homo(:)
       !> Number of electrons
       real(wp), allocatable :: nel(:)
       !> Reference occupation number for each atom, shape: [nat]
@@ -92,7 +90,6 @@ subroutine new_wavefunction(self, nat, nsh, nao, nspin, kt, grad)
    self%nspin = nspin
    self%kt = kt
 
-   allocate(self%homo(max(2, nspin)))
    allocate(self%nel(max(2, nspin)))
 
    allocate(self%n0at(nat))
@@ -101,7 +98,7 @@ subroutine new_wavefunction(self, nat, nsh, nao, nspin, kt, grad)
    allocate(self%density(nao, nao, nspin))
    allocate(self%coeff(nao, nao, nspin))
    allocate(self%emo(nao, nspin))
-   allocate(self%focc(nao, nspin))
+   allocate(self%focc(nao, max(2, nspin)))
 
    allocate(self%qat(nat, nspin))
    allocate(self%qsh(nsh, nspin))

--- a/src/tblite/xtb/singlepoint.f90
+++ b/src/tblite/xtb/singlepoint.f90
@@ -99,7 +99,6 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
    real(wp), allocatable :: cn(:), dcndr(:, :, :), dcndL(:, :, :), dEdcn(:)
    real(wp), allocatable :: selfenergy(:), dsedcn(:), lattr(:, :), wdensity(:, :, :)
    type(integral_type) :: ints
-   real(wp), allocatable :: tmp(:)
    type(potential_type) :: pot
    type(container_cache), allocatable :: ccache, dcache, icache, hcache, rcache
    class(mixer_type), allocatable :: mixer
@@ -122,8 +121,6 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
 
    econv = 1.e-6_wp*accuracy
    pconv = 2.e-5_wp*accuracy
-
-   call ctx%new_solver(solver, calc%bas%nao)
 
    grad = present(gradient) .and. present(sigma)
 
@@ -232,6 +229,8 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
    call new_integral(ints, calc%bas%nao)
    call get_hamiltonian(mol, lattr, list, calc%bas, calc%h0, selfenergy, &
       & ints%overlap, ints%dipole, ints%quadrupole, ints%hamiltonian)
+
+   call ctx%new_solver(solver, ints%overlap, wfn%nel, wfn%kt)
    call timer%pop
 
    call timer%push("scc")
@@ -285,8 +284,10 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
       call ctx%message("")
    end if
 
-   call ctx%delete_solver(solver)
-   if (ctx%failed()) return
+   if (ctx%failed()) then
+      call ctx%delete_solver(solver)
+      return
+   end if
 
    if (grad) then
       if (allocated(calc%coulomb)) then
@@ -312,10 +313,7 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
       dEdcn(:) = 0.0_wp
 
       allocate(wdensity(calc%bas%nao, calc%bas%nao, wfn%nspin))
-      do spin = 1, wfn%nspin
-         tmp = wfn%focc(:, spin) * wfn%emo(:, spin)
-         call get_density_matrix(tmp, wfn%coeff(:, :, spin), wdensity(:, :, spin))
-      end do
+      call solver%get_wdensity(wfn%coeff, ints%overlap, wfn%emo, wfn%focc, wdensity, error)
       call updown_to_magnet(wfn%density)
       call updown_to_magnet(wdensity)
       call get_hamiltonian_gradient(mol, lattr, list, calc%bas, calc%h0, selfenergy, &
@@ -330,6 +328,10 @@ subroutine xtb_singlepoint(ctx, mol, calc, wfn, accuracy, energy, gradient, sigm
       end if
       call timer%pop
    end if
+
+   call ctx%delete_solver(solver)
+   if (ctx%failed()) return
+
    if (present(post_process)) then
       call timer%push("post processing")
       call collect_containers_caches(rcache, ccache, hcache, dcache, icache, calc, cache_list)

--- a/test/unit/test_wavefunction_restart.f90
+++ b/test/unit/test_wavefunction_restart.f90
@@ -195,7 +195,6 @@ subroutine test_kt_mismatch(error)
 
    call save_npz(filename, prefix//"kt", [wfn%kt, wfn%kt])
 
-   call save_npz(filename, prefix//"homo", wfn%homo)
    call save_npz(filename, prefix//"nel", wfn%nel)
    call save_npz(filename, prefix//"n0at", wfn%n0at)
    call save_npz(filename, prefix//"n0sh", wfn%n0sh)
@@ -228,7 +227,6 @@ subroutine test_dipole_mismatch(error)
 
    call save_npz(filename, prefix//"kt", [wfn%kt])
 
-   call save_npz(filename, prefix//"homo", wfn%homo)
    call save_npz(filename, prefix//"nel", wfn%nel)
    call save_npz(filename, prefix//"n0at", wfn%n0at)
    call save_npz(filename, prefix//"n0sh", wfn%n0sh)
@@ -261,7 +259,6 @@ subroutine test_quadrupole_mismatch(error)
 
    call save_npz(filename, prefix//"kt", [wfn%kt])
 
-   call save_npz(filename, prefix//"homo", wfn%homo)
    call save_npz(filename, prefix//"nel", wfn%nel)
    call save_npz(filename, prefix//"n0at", wfn%n0at)
    call save_npz(filename, prefix//"n0sh", wfn%n0sh)
@@ -294,7 +291,6 @@ subroutine test_load_error(error)
 
    call save_npz(filename, prefix//"kt", [1, 1, 1])
 
-   call save_npz(filename, prefix//"homo", wfn%homo)
    call save_npz(filename, prefix//"nel", wfn%nel)
    call save_npz(filename, prefix//"n0at", wfn%n0at)
    call save_npz(filename, prefix//"n0sh", wfn%n0sh)


### PR DESCRIPTION
Changes the solver object to produce a density matrix from a given Hamiltonian.

* solver is split in two classes, the context solver factory and the solver instance
* the context solver creates new solver instances based on the overlap matrix, number of electrons and other input parameters
* the solver instance gets deregistered after the SCF, it must not persist between single point calculations
* persistent memory can be allocated in the context solver and referenced in the solver instance via pointers (assigned in `new_solver`, removed in `delete_solver` or persisted)

Closes https://github.com/tblite/tblite/pull/262