### PR TITLE
Fix CPCM xtbml energy bug

### DIFF
--- a/src/tblite/post_processing/xtb-ml/energy.f90
+++ b/src/tblite/post_processing/xtb-ml/energy.f90
@@ -172,9 +172,9 @@ subroutine compute_features(self, mol, wfn, integrals, calc, cache_list)
    if (allocated(calc%interactions)) then
       call move_alloc(cache_list(5)%raw, cache%raw)
       associate(cont => calc%interactions)
+         call cont%get_energy(mol, cache, wfn, tmp_energy)
          call cont%update(mol, cache)
          call cont%get_engrad(mol, cache, tmp_energy)
-         call cont%get_energy(mol, cache, wfn, tmp_energy)
          call self%dict%add_entry(cont%info(0, ""), tmp_energy)
       end associate
    end if


### PR DESCRIPTION
As described by #287, we get a segmentation fault when running the `xtbml` post-processing features  together with CPCM. This comes from the cache update function of CPCM with a subsequent call to `get_energy` without first calling `get_potential`. I fixed it by changing the order in which I call these functions.

However, it might be an idea to take a look at the update function of CPCM, since I don't think that we need to deallocate the cache every time we call update. @awvwgk you implemented this solvation, can you take a look, since ALPB for example doesn't use this deallocate everything strategy.