### PR TITLE
Incorrect placement of shell resolved mulliken properties in post processing dictionary

### DIFF
--- a/src/tblite/post_processing/xtb-ml/density.f90
+++ b/src/tblite/post_processing/xtb-ml/density.f90
@@ -14,7 +14,7 @@
 ! along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 
 !> @file tblite/post-processing/xtb-ml/density.f90
-!> Desnity based features using Mulliken partitioning
+!> Density based features using Mulliken partitioning
 module tblite_xtbml_density_based
    use mctc_env, only : wp
    use mctc_io, only : structure_type

--- a/src/tblite/post_processing/xtb-ml/density.f90
+++ b/src/tblite/post_processing/xtb-ml/density.f90
@@ -520,7 +520,7 @@ subroutine mulliken_shellwise(ao2shell, p, s, charges_shell)
       do mu = 1, nao
          do nu = 1, nao
             !$omp atomic
-            charges_shell(ao2shell(mu), spin) = charges_shell(ao2shell(mu), spin) + p(mu, nu, spin)*s(mu, nu)
+            charges_shell(ao2shell(mu), spin) = charges_shell(ao2shell(mu), spin) + p(nu, mu, spin)*s(nu, mu)
          end do
       end do
    end do


### PR DESCRIPTION
While using tblite to generate xtbml density properties for iron complexes, I noticed that the properties resolved into separate s,p,d shells were placed into the wrong corresponding keys in the post processing dictionary. For instance for the following iron complex with -1 charge and 5 unpaired electrons:

```
102
xtb: 6.7.1 (edcfbbe)
Fe         2.70780       15.91780        9.49120
Si         5.66930       16.07430       11.18820
Si        -0.25520       16.05550       11.21360
Si         2.71770       15.12150        6.13410
N          2.68840       18.39010        9.01150
N          4.63350       16.58510        9.92240
N          1.25750       16.72020       10.75250
N          2.22400       16.08620        7.46510
C          4.07480       18.84110        9.19770
H          4.19690       19.19290       10.22570
H          4.31990       19.66110        8.51210
C          5.00090       17.64480        8.97070
H          4.88160       17.28180        7.94180
H          6.04180       17.96960        9.09240
C          0.70790       13.81940       12.84800
H          0.25270       13.10560       12.15900
H          0.79420       13.33990       13.82650
H          1.71480       14.04220       12.48920
C          2.22240       18.51960        7.62340
H          3.09120       18.55550        6.96060
H          1.63590       19.43600        7.48680
C          1.38770       17.28370        7.28090
H          0.51570       17.23720        7.94610
H          1.01760       17.37860        6.25240
C          4.29970       14.12790        6.57200
H          4.64690       13.51800        5.73190
H          4.16990       13.43830        7.41210
H          5.13950       14.77840        6.84090
C          3.12270       16.19850        4.58850
H          3.51880       15.60980        3.75530
H          3.87960       16.95830        4.81160
H          2.25790       16.74040        4.19370
C          1.31180       13.82760        5.60630
C          1.03050       12.80070        6.72700
H          0.23510       12.11330        6.42710
H          0.71530       13.30490        7.64270
H          1.92110       12.21170        6.95320
C          1.71080       13.03020        4.34320
H          0.92920       12.31040        4.08570
H          2.63830       12.47900        4.50690
H          1.85270       13.69550        3.49010
C         -0.02370       14.54460        5.30090
H          0.09750       15.27330        4.49740
H         -0.39150       15.06720        6.18600
H         -0.78400       13.82200        4.99320
C          2.68760       13.93360        9.82510
C          2.57610       12.72060        9.93990
C          2.41450       11.31380       10.06130
C          3.52180       10.46500       10.19000
H          4.51940       10.89010       10.20310
C          3.34870        9.09520       10.29800
H          4.21400        8.44880       10.39660
C          2.07220        8.54550       10.27930
H          1.94010        7.47300       10.36300
C          0.96570        9.37760       10.15280
H         -0.03190        8.95230       10.13810
C          1.13160       10.74780       10.04530
H          0.26750       11.39580        9.94570
C          6.67520       17.54390       11.92210
H          7.38580       17.98200       11.21440
H          7.25930       17.25850       12.80230
H          6.02220       18.36330       12.24170
C          4.64600       15.29590       12.61210
H          4.02610       14.45140       12.29380
H          3.96240       16.01560       13.07620
H          5.28110       14.91760       13.41940
C          6.96520       14.71650       10.55780
C          7.70870       15.20000        9.29150
H          8.43690       14.45280        8.96570
H          8.24120       16.13350        9.48260
H          7.00540       15.36780        8.47350
C          8.03130       14.39630       11.63080
H          8.71040       13.61820       11.27210
H          7.56400       14.04090       12.55080
H          8.62460       15.28100       11.86680
C          6.26350       13.38690       10.19740
H          5.49630       13.54520        9.43660
H          5.78560       12.94860       11.07530
H          6.98570       12.66530        9.80680
C          1.75910       18.97550        9.98770
H          0.76370       19.03310        9.53910
H          2.07430       19.98450       10.27940
C          1.70230       18.04820       11.20300
H          2.70030       17.97670       11.65420
H          1.02780       18.48040       11.95280
C         -1.60030       17.42330       11.39150
H         -1.67320       18.04160       10.49030
H         -1.41280       18.11510       12.21840
H         -2.60020       17.01210       11.56020
C         -0.87330       14.80370        9.89740
H         -1.04140       15.27350        8.92180
H         -1.82520       14.34340       10.18050
H         -0.17930       13.97610        9.71890
C         -0.13860       15.10870       12.95030
C         -1.53520       14.69920       13.47240
H         -2.15740       15.57720       13.65220
H         -1.44310       14.15040       14.41350
H         -2.04710       14.05660       12.75390
C          0.51710       16.00140       14.02930
H          1.53840       16.26170       13.74470
H          0.55450       15.47830       14.98840
H         -0.04610       16.92610       14.16770
```

the shell resolved mulliken populations for the iron center and a nitrogen atom are the following:
<img width="381" height="153" alt="image" src="https://github.com/user-attachments/assets/5018dda1-87f7-40cd-bf58-6054693bffd2" />

While the nitrogen populations make sense, the iron populations are illogical. What I noticed is that, when comparing the spin populations produced by xtb (as opposed to xtb through tblite), what the post processing dictionary indicates as the "s" population, is actually the d-shell population, the "p" population is actually the s-shell population, and the "d" population is the p-shell population. 

This is a result of the current code assuming that the shells are ordered s,p,d in the population and overlap matrices, however for certain elements, such as iron, the ordering is actually d,s,p, as a result of definitions in /src/tblite/xtb/gfn1.f90 and /src/tblite/xtb/gfn2.f90.

To fix this, the functions resolve_shellwise() and resolve_xyz_shell() in /src/tblite/post_processing/xtb-ml/density.f90 were altered to take into account the shell ordering using the cgto array in basis_type, which includes the angular momentum of each shell. Furthermore, the code was simplified in resolve_xyz_shell() to make use of a single loop to obtain each shell resolved property. With these changes, the iron shell resolved mulliken populations are placed under the correct keys in the post processing dictionary without affecting elements which were previously fine:
<img width="400" height="153" alt="image" src="https://github.com/user-attachments/assets/ba0009f2-e726-40d5-80f2-2c7fa83f1300" />