### PR TITLE
Run `wheel.yml` for `macos-latest` again

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -116,6 +116,8 @@ jobs:
           CIBW_BUILD: "*${{ matrix.python }}-*"
           # MM: Package installation (yum install ...) works differently on musllinux
           CIBW_SKIP: "*musllinux*"
+          # Include all PyPy versions
+          CIBW_ENABLE: pypy pypy-eol
           # Control verbosity of the 'pip wheel' output
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: yum install -y lapack-devel

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -97,7 +97,7 @@ jobs:
 
       # Install 'cibuildwheel' as the driver for building wheels
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.23.3
+        run: python -m pip install cibuildwheel==3.3.0
 
       # Download the source distribution from above
       - name: Download sdist

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -81,7 +81,7 @@ jobs:
         # macos-latest
         # windows-latest
         python: ['39', '310', '311', '312', '313']
-        include: 
+        include:
           - os: ubuntu-22.04
             python: '38'
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -134,7 +134,7 @@ jobs:
             PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig
             LDFLAGS=-L/opt/homebrew/opt/openblas/lib
             CPPFLAGS=-I/opt/homebrew/opt/openblas/include
-            MACOSX_DEPLOYMENT_TARGET=14.0
+            MACOSX_DEPLOYMENT_TARGET=15.0
 
       # Upload the built wheels as artifacts
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -123,7 +123,6 @@ jobs:
           # MM: 'openblas' from brew requires gcc@15, using a different version for building leads to delocation errors
           # MM: gcc@14 needs macOS14
           CIBW_BEFORE_ALL_MACOS: |
-            brew uninstall gcc@12
             brew uninstall gcc@13
             brew uninstall gcc@14
             brew autoremove

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -78,7 +78,7 @@ jobs:
         os:
         - ubuntu-latest
         # macos-13
-        # macos-latest
+        - macos-latest
         # windows-latest
         python: ['39', '310', '311', '312', '313']
         include:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -119,17 +119,18 @@ jobs:
           # Control verbosity of the 'pip wheel' output
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: yum install -y lapack-devel
-          # Delete all other (=/= gcc-14) GCC versions to avoid conflicts in delocation of the wheel
-          # MM: 'openblas' from brew requires gcc@14, using a different version for building leads to delocation errors
+          # Delete all other (=/= gcc-15) GCC versions to avoid conflicts in delocation of the wheel
+          # MM: 'openblas' from brew requires gcc@15, using a different version for building leads to delocation errors
           # MM: gcc@14 needs macOS14
           CIBW_BEFORE_ALL_MACOS: |
             brew uninstall gcc@12
             brew uninstall gcc@13
+            brew uninstall gcc@14
             brew autoremove
             brew install openblas
           # Set macOS variables to find gfortran, lapack, and avoid testing against macOS earlier than 14 (see above)
           CIBW_ENVIRONMENT_MACOS: >
-            CC=gcc-14 CXX=g++-14 FC=gfortran-14
+            CC=gcc-15 CXX=g++-15 FC=gfortran-15
             PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig
             LDFLAGS=-L/opt/homebrew/opt/openblas/lib
             CPPFLAGS=-I/opt/homebrew/opt/openblas/include

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -80,7 +80,7 @@ jobs:
         # macos-13
         - macos-latest
         # windows-latest
-        python: ['39', '310', '311', '312', '313']
+        python: ['39', '310', '311', '312', '313', '314']
         include:
           - os: ubuntu-22.04
             python: '38'


### PR DESCRIPTION
First of all, always thank you so much `tblite` developers and maintainers for your efforts!

# Summary

This PR suggests re-making the wheels for Apple Silicon macOS again.
With this, I would like to request to make them available again on PyPI, hopefully from the next release.

# Details

Wheels for Apple Silicon macOS were available in 0.4.0, and therefore pip-installation was easy.
```
% pip install tblite==0.4.0
Collecting tblite==0.4.0
  Downloading tblite-0.4.0-cp313-cp313-macosx_14_0_arm64.whl.metadata (5.8 kB)
Requirement already satisfied: cffi in ./miniforge3/envs/python-3.13/lib/python3.13/site-packages (from tblite==0.4.0) (1.17.1)
Requirement already satisfied: numpy in ./miniforge3/envs/python-3.13/lib/python3.13/site-packages (from tblite==0.4.0) (2.3.2)
Requirement already satisfied: pycparser in ./miniforge3/envs/python-3.13/lib/python3.13/site-packages (from cffi->tblite==0.4.0) (2.22)
Downloading tblite-0.4.0-cp313-cp313-macosx_14_0_arm64.whl (10.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.7/10.7 MB 6.1 MB/s eta 0:00:00
Installing collected packages: tblite
Successfully installed tblite-0.4.0
```
However, since [this commit](https://github.com/tblite/tblite/pull/271/commits/bf6ce48272f8f5557c728f1a28a905d78ea61758), wheels are not made for Apple Silicon macOS, and thus [PyPI does not have wheels for them](https://pypi.org/project/tblite/0.5.0/#files).
As a result, simple pip-installation fails as follows.
```
% pip install tblite==0.5.0
Collecting tblite==0.5.0
  Downloading tblite-0.5.0.tar.gz (861 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 862.0/862.0 kB 24.2 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      + meson setup /private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f /private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f/.mesonpy-athgcaoa -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f/.mesonpy-athgcaoa/meson-python-native-file.ini
      The Meson build system
      Version: 1.9.1
      Source dir: /private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f
      Build dir: /private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f/.mesonpy-athgcaoa
      Build type: native build
      Project name: tblite
      Project version: 0.5.0
      C compiler for the host machine: cc (clang 17.0.0 "Apple clang version 17.0.0 (clang-1700.4.4.1)")
      C linker for the host machine: cc ld64 1230.1
      Host machine cpu family: aarch64
      Host machine cpu: aarch64
      Found pkg-config: YES (/Users/ikeda/miniforge3/envs/python-3.13/bin/pkg-config) 0.29.2
      Found CMake: /Users/ikeda/miniforge3/envs/python-3.13/bin/cmake (4.0.0)
      Run-time dependency tblite found: NO (tried pkgconfig, framework and cmake)
      Looking for a fallback subproject for the dependency tblite

      Executing subproject tblite

      tblite| Project name: tblite
      tblite| Project version: 0.5.0

      ../subprojects/tblite/meson.build:17:0: ERROR: Compiler gfortran cannot compile programs.

      A full log can be found at /private/var/folders/t5/tgnxd1t14qzcl85h5c9w8v2r0000gn/T/pip-install-f7clxrml/tblite_bffd07078ba54b57a9f120362d24776f/.mesonpy-athgcaoa/meson-logs/meson-log.txt
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

I believe there are a certain amount of demands for `tblite` on macOS, so it would be nice to make the wheel re-available for them.