### PR TITLE
Use compiliers/libraries not in $DEVTOOLSET_ROOT

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -136,6 +136,7 @@ jobs:
             LDFLAGS=-L/opt/homebrew/opt/openblas/lib
             CPPFLAGS=-I/opt/homebrew/opt/openblas/include
             MACOSX_DEPLOYMENT_TARGET=15.0
+          CIBW_TEST_COMMAND: python -c "import tblite.interface"
 
       # Upload the built wheels as artifacts
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -121,6 +121,20 @@ jobs:
           # Control verbosity of the 'pip wheel' output
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: yum install -y lapack-devel
+          # Use compiliers/libraries not in $DEVTOOLSET_ROOT
+          # LAPACK installed by `yum install -y lapack-devel` in AlmaLinux 8
+          # in manylinux_2_28 may be compiled with gcc-gfortran 8.5.0, while
+          # AlmaLinux 8 also has GCC 14 from devtoolset-14 installed
+          # in $DEVTOOLSET_ROOT.
+          # To avoid conflicts, we specify LAPACK-compatible compilers/libraries.
+          # https://cibuildwheel.pypa.io/en/v3.3.0/options/#linux-image
+          # https://github.com/pypa/manylinux
+          CIBW_ENVIRONMENT_LINUX: >
+            CC=/usr/bin/gcc
+            CXX=/usr/bin/g++
+            FC=/usr/bin/gfortran
+            LD_LIBRARY_PATH=/usr/lib64
+            C_INCLUDE_PATH=/usr/include
           # Delete all other (=/= gcc-15) GCC versions to avoid conflicts in delocation of the wheel
           # MM: 'openblas' from brew requires gcc@15, using a different version for building leads to delocation errors
           # MM: gcc@14 needs macOS14


### PR DESCRIPTION
Closes #286

# Summary

This PR fixes the issue reported in #286.
I found the wheels of v0.5.0 for Linux are broken, likely due to the conflicts between `gcc-gfortran-8` used in LAPACK installed with `yum` and `gcc-gfortran-14` in `$DEVTOOLSET_ROOT` already installed in the `manylinux` image (AlmaLinux 8 in `manylinux_2_28`).
To avoid the conflicts, in this PR, I specify the ones consistent with LAPACK.
The tests are also added to ensure that the fixed wheels are really importable in Python.

# Details

The update of `cibuildwheel` to `3.3.0` (#297) ensures that it calls the `manylinux_2_28` image, which can install more recent LAPACK compared with `manylinux2014`.

The next commit 21c21abf6f55351960dfe961eaae9c2cf39e43e2 adds `CIBW_TEST_COMMAND` to test whether the created wheels are really importable.
This can avoid buggy wheels to be uploaded to PyPI in future.
At this point, as expected, the wheels show an error reported in #286. (Please refer to the results in my fork https://github.com/yuzie007/tblite/actions/runs/19797710364).

The last commit 87342ff6ed0db353a2e3ca6f8f1ddb1150e0c6c2 fixes the issue to use the compilers and the libraries compatible with LAPACK installed via `yum`.
After this fix, tests added above have passed (https://github.com/tblite/tblite/actions/runs/19799510554?pr=299).