### PR TITLE
Add `libgfortran` and `libmvec` explicitly when making Python wheels for Linux

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -136,6 +136,7 @@ jobs:
             LDFLAGS=-L/opt/homebrew/opt/openblas/lib
             CPPFLAGS=-I/opt/homebrew/opt/openblas/include
             MACOSX_DEPLOYMENT_TARGET=15.0
+          CIBW_TEST_COMMAND: python -c "import tblite.interface"
 
       # Upload the built wheels as artifacts
       - uses: actions/upload-artifact@v4

--- a/config/meson.build
+++ b/config/meson.build
@@ -36,7 +36,10 @@ if fc_id == 'gcc'
   # - _gfortran_os_error_at (from libfortran.so)
   if os == 'linux'
     lib_deps += cc.find_library('gfortran')
-    lib_deps += cc.find_library('mvec')
+    mvec_dep = cc.find_library('mvec', required: false)
+    if mvec_dep.found()
+        lib_deps += mvec_dep
+    endif
     lib_deps += cc.find_library('m')
   endif
   if fc.version().version_compare('<10')

--- a/config/meson.build
+++ b/config/meson.build
@@ -29,6 +29,16 @@ if fc_id == 'gcc'
     '-Wno-maybe-uninitialized',
     language: 'fortran',
   )
+  # Particularly for the manylinux image to make Python wheels,
+  # the libraries below seem to be necessary to add explicitly to avoid
+  # undefined symbol errors such as:
+  # - _ZGVbN2v_exp (from libmvec.so)
+  # - _gfortran_os_error_at (from libfortran.so)
+  if os == 'linux'
+    lib_deps += cc.find_library('gfortran')
+    lib_deps += cc.find_library('mvec')
+    lib_deps += cc.find_library('m')
+  endif
   if fc.version().version_compare('<10')
     message('tblite it not tested with GNU Fortran < 10, functionality might be impacted. The build automatically adds ‘-fno-range-check’ for compatibility. Please upgrade to a newer compiler version if possible.') 
     add_project_arguments(


### PR DESCRIPTION
closes #286, closes #278

# Summary

This PR solves the `undefined symbol` errors such as `_ZGVbN2v_exp` and `_gfortran_os_error_at`, reported for Python wheels for Linux in #286, by explicitly adding `libfortran` and `libmvec` (together with `libm` for safety) as dependency libraries.

# Details

The function like `_ZGVbN2v_exp` comes from [`libmvec.so`](http://libmvec.so/).
- https://sourceware.org/glibc/wiki/libmvec
- https://sourceware.org/glibc/wiki/libmvec?action=AttachFile&do=view&target=VectorABI.txt

Similarly, `_gfortran_os_error_at`comes from [`libgfortran.so`](http://libgfortran.so/).
- https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libgfortran/gfortran.map
- https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=libgfortran/ChangeLog-2019

In principle, these libraries are supposed to be linked automatically without explicit specification.
However, maybe in some environment like `manylinux` for making Python wheels, this is not fully guaranteed, maybe to make the code available also for old environments, resulted in the above `undefined symbol` errors.
We can solve this issue by adding these necessary libraties explicitly, as confirmed in [GitHub Actions CI](https://github.com/yuzie007/tblite/actions/runs/19967380974).

I also added `CIBW_TEST_COMMAND` to ensure that the created wheels are really importable.
This can avoid buggy wheels to be uploaded to PyPI in future.

This fix also solves the documentation build failure reported in #278, as found in [ReadTheDocs](https://app.readthedocs.org/projects/tblite/builds/30583255/).