### PR TITLE
Make Python wheels also for Intel MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,43 +32,43 @@ jobs:
           - {compiler: gcc, version: '12', build: cmake}
 
         include:
-        - os: ubuntu-latest
-          build-type: coverage
-          toolchain: {compiler: gcc, version: '10', build: meson}
+          - os: ubuntu-latest
+            build-type: coverage
+            toolchain: {compiler: gcc, version: '10', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: gcc, version: '11', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: gcc, version: '11', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: gcc, version: '13', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: gcc, version: '13', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: gcc, version: '14', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: gcc, version: '14', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: intel-classic, version: '2021.2', mkl_version: '2021.2.0', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: intel-classic, version: '2021.2', mkl_version: '2021.2.0', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: intel, version: '2024.1', mkl_version: '2024.1', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: intel, version: '2024.1', mkl_version: '2024.1', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: intel, version: '2025.1', mkl_version: '2025.1', build: meson}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: intel, version: '2025.1', mkl_version: '2025.1', build: meson}
 
-        - os: ubuntu-latest
-          build-type: debug
-          toolchain: {compiler: gcc, version: '12', build: fpm}
+          - os: ubuntu-latest
+            build-type: debug
+            toolchain: {compiler: gcc, version: '12', build: fpm}
 
-        # - os: windows-latest
-        #   build: meson
-        #   build-type: debug
-        #   compiler: gcc
-        #   shell: msys2 {0}
+          # - os: windows-latest
+          #   build: meson
+          #   build-type: debug
+          #   compiler: gcc
+          #   shell: msys2 {0}
 
     defaults:
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,10 @@ jobs:
             build-type: debug
             toolchain: {compiler: gcc, version: '12', build: fpm}
 
+          - os: macos-15-intel
+            build-type: debug
+            toolchain: {compiler: gcc, version: '12', build: meson}
+
           # - os: windows-latest
           #   build: meson
           #   build-type: debug
@@ -89,9 +93,9 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') && matrix.toolchain.compiler == 'gcc' }}
       run: |
         brew install openblas
-        echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
-        echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
-        echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$(brew --prefix openblas)/lib/pkgconfig" >> $GITHUB_ENV
+        echo "LDFLAGS=-L$(brew --prefix openblas)/lib" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I$(brew --prefix openblas)/include" >> $GITHUB_ENV
 
     - name: Install LAPACK (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.toolchain.compiler == 'gcc' }}
@@ -288,6 +292,11 @@ jobs:
           gcc_v: '12'
           python_v: '3.12'
 
+        include:
+        - os: macos-15-intel
+          gcc_v: '12'
+          python_v: '3.12'
+
     env:
       FC: gfortran
       CC: gcc
@@ -308,9 +317,9 @@ jobs:
       if: ${{ contains(matrix.os, 'macos')}}
       run: |
         brew install openblas
-        echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
-        echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
-        echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$(brew --prefix openblas)/lib/pkgconfig" >> $GITHUB_ENV
+        echo "LDFLAGS=-L$(brew --prefix openblas)/lib" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I$(brew --prefix openblas)/include" >> $GITHUB_ENV
 
     - name: Install LAPACK (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -76,10 +76,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest
-        # macos-13
-        - macos-latest
-        # windows-latest
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+          # windows-latest
         python: ['39', '310', '311', '312', '313', '314']
         include:
           - os: ubuntu-22.04
@@ -132,9 +132,9 @@ jobs:
           # Set macOS variables to find gfortran, lapack, and avoid testing against macOS earlier than 14 (see above)
           CIBW_ENVIRONMENT_MACOS: >
             CC=gcc-15 CXX=g++-15 FC=gfortran-15
-            PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig
-            LDFLAGS=-L/opt/homebrew/opt/openblas/lib
-            CPPFLAGS=-I/opt/homebrew/opt/openblas/include
+            PKG_CONFIG_PATH="$(brew --prefix openblas)/lib/pkgconfig"
+            LDFLAGS="-L$(brew --prefix openblas)/lib"
+            CPPFLAGS="-I$(brew --prefix openblas)/include"
             MACOSX_DEPLOYMENT_TARGET=15.0
 
       # Upload the built wheels as artifacts


### PR DESCRIPTION
This PR is a follow-up of #297.

This PR makes wheels also for Intel MacOS, under the same motivation as #297.

This also includes robustification of openblas-related-path specifications, in the same manner as [DFTD4](https://github.com/dftd4/dftd4/blob/v4.0.0/.github/workflows/wheel.yml), which is necessary as [the homebrew installation location is different between Intel and Apple-Silicon MacOS](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location).