### PR TITLE
Loosen `THR` in `python/tblite/test_interface.py`

### DIFF
--- a/python/tblite/test_interface.py
+++ b/python/tblite/test_interface.py
@@ -23,7 +23,7 @@ from pytest import approx, raises
 from tblite.exceptions import TBLiteRuntimeError, TBLiteValueError
 from tblite.interface import Calculator, Result, symbols_to_numbers
 
-THR = 1.0e-9
+THR = 1.0e-6
 
 
 def get_ala(conf):


### PR DESCRIPTION
closes #303

As described in the issue above, this PR loosens `THR` in `python/tblite/test_interface.py` to make the tests robust.