### PR TITLE
Fix the `C-API` issue for arrays of strings

### DIFF
--- a/src/tblite/api/table.f90
+++ b/src/tblite/api/table.f90
@@ -244,7 +244,7 @@ subroutine table_set_char_api(verror, vtable, ckey, cval, n) &
 
    call c_f_pointer(vtable, table)
    call c_f_character(ckey, key)
-   call c_f_pointer(cval, carr, [strlen(cval)+1, min(n, 1)])
+   call c_f_pointer(cval, carr, [strlen(cval)+1, max(n, 1)])
 
    if (table%ptr%has_key(key)) call table%ptr%delete(key)
 


### PR DESCRIPTION
closes (maybe) #288

When I compile `tblite` with the `-fcheck=all` option on GitHub Actions CI ([here](https://github.com/yuzie007/tblite/actions/runs/20241791952/job/58111582732)), the `C-API` test fails for a job with the following message:
```
89/89 api - tblite:C-API FAIL 0.09s exit status 2 
...
Start test: table-builder 
stderr: 
At line 259 of file ../src/tblite/api/table.f90 
Fortran runtime error: Index '1' of dimension 2 of array 'carr' outside of expected range (1:0) 
```

I found this happens probably due to a typo in `src/tblite/api/table.f90:tblite_api_table:table_set_char_api`.
Specifically, this function is supposed to accept either a single string or a array of strings, and `n` (size of the array) should be `=0` and `>0` for the former and the latter cases, respectively.
Then, for the latter case, the `carr` pointer should have the shape corresponding to the array of strings.
However, the present implementation does not set the correct shape due to the typo of `max(n, 1)` as `min(n, 1)`.
The present PR fixes this.

After the fix above, the test in corresponding job in the CI suceeed ([here](https://github.com/yuzie007/tblite/actions/runs/20241849465/job/58111775749)).
I also confirmed the `C-API` failure on Windows on conda-forge feedstock is solved by the corresponding patch (please compare [this](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1418474&view=logs&j=fe7faf59-69bb-5487-b8fd-a35a7bda3a51&t=55731638-dd49-5144-2129-5101b9dd1960) with [the previous one](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1416358&view=logs&j=fe7faf59-69bb-5487-b8fd-a35a7bda3a51&t=55731638-dd49-5144-2129-5101b9dd1960)).
Hopefully, the present fix will also solve the `C-API` error in https://github.com/tblite/tblite/issues/288#issue-3289140647 (note that I believe the remaining `npz` related errors, including `double-dictionary` and `wavefunction-restart`, have already been solved in #307; please also refer to https://github.com/conda-forge/tblite-feedstock/pull/20#issuecomment-3640841958).