### PR TITLE
QCSchema v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         gcc_v: ['12']
-        python_v: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python_v: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
         include:
         - os: macos-latest
@@ -331,6 +331,10 @@ jobs:
       with:
         compiler: gcc
         version: ${{ matrix.gcc_v }}
+
+    - name: Install QCSchema v2 for Py 313+
+      if: ((matrix.python_v == '3.14') || (matrix.python_v == '3.13'))
+      run: pip3 install "qcelemental>=0.50.0rc3"
 
     - name: Install meson and test dependencies
       run: pip3 install ${{ env.PIP_EXTRAS }}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
    "numpy",
 ]
 optional-dependencies.ase = ["ase"]
+optional-dependencies.qcschema = [
+  "qcelemental; python_version < '3.14'",
+  "qcelemental>=0.50.0rc3; python_version >= '3.14'",
+]
 optional-dependencies.test = [
   "pytest",
   "pytest-cov",

--- a/python/tblite/qcschema.py
+++ b/python/tblite/qcschema.py
@@ -63,15 +63,35 @@ Supported keywords are:
 =================== ==================================== =========================================
 """
 
+import sys
 from io import StringIO
-from typing import Any, Dict, Union
+from typing import Any, Dict, Literal, overload, Union
 
 import numpy as np
-import qcelemental as qcel
 
 from .exceptions import TBLiteRuntimeError, TBLiteTypeError, TBLiteValueError
 from .interface import Calculator
 from .library import get_version
+
+if sys.version_info < (3, 14):
+    try:
+        import qcelemental.models.v1 as qcel_v1
+    except ModuleNotFoundError:
+        import qcelemental.models as qcel_v1
+else:
+    qcel_v1 = None
+
+try:
+    import qcelemental.models.v2 as qcel_v2
+except ModuleNotFoundError:
+    qcel_v2 = None
+
+
+if qcel_v1 is None and qcel_v2 is None:
+    raise ModuleNotFoundError(
+        "The qcelemental package is required for qcschema support. "
+        "Please install it with 'pip install qcelemental'."
+    )
 
 SUPPORTED_DRIVERS = {
     "energy",
@@ -81,7 +101,43 @@ SUPPORTED_DRIVERS = {
 }
 
 
-def get_provenance() -> qcel.models.Provenance:
+if qcel_v1 is not None:
+
+    @overload
+    def get_provenance(schema_version: Literal[1]) -> "qcel_v1.Provenance": ...
+
+    @overload
+    def get_error(
+        input_data: "qcel_v1.AtomicInput",
+        error: Union[Dict[str, Any], "qcel_v1.ComputeError"],
+        schema_version: int,
+    ) -> "qcel_v1.AtomicResult": ...
+
+    @overload
+    def run_schema(
+        input_data: Union[Dict[str, Any], "qcel_v1.AtomicInput"],
+    ) -> Union["qcel_v1.AtomicResult", "qcel_v1.FailedOperation"]: ...
+
+
+if qcel_v2 is not None:
+
+    @overload
+    def get_provenance(schema_version: Literal[2]) -> "qcel_v2.Provenance": ...
+
+    @overload
+    def get_error(
+        input_data: "qcel_v2.AtomicInput",
+        error: Union[Dict[str, Any], "qcel_v2.ComputeError"],
+        schema_version: int,
+    ) -> "qcel_v2.FailedOperation": ...
+
+    @overload
+    def run_schema(
+        input_data: Union[Dict[str, Any], "qcel_v2.AtomicInput"],
+    ) -> Union["qcel_v2.AtomicResult", "qcel_v2.FailedOperation"]: ...
+
+
+def get_provenance(schema_version: Literal[1, 2]):
     """
     Returns a QCSchema provenance model.
 
@@ -90,40 +146,59 @@ def get_provenance() -> qcel.models.Provenance:
     qcel.models.Provenance
         A QCSchema provenance model.
     """
-    return qcel.models.Provenance(
+    prov = dict(
         creator="tblite",
         version=".".join([str(v) for v in get_version()]),
         routine="tblite.qcschema.run_schema",
     )
+    if schema_version == 1:
+        return qcel_v1.Provenance(**prov)
+    elif schema_version == 2:
+        return qcel_v2.Provenance(**prov)
+    else:
+        raise ValueError(
+            f"Unsupported QCSchema version: {schema_version}. Only v1 and v2 are supported."
+        )
 
 
-def get_error(
-    input_data: qcel.models.AtomicInput,
-    error: Union[Dict[str, Any], qcel.models.ComputeError],
-) -> qcel.models.AtomicResult:
-    if not isinstance(error, qcel.models.ComputeError):
-        error = qcel.models.ComputeError(**error)
+def get_error(input_data, error, schema_version):
+    if schema_version == 1:
+        if not isinstance(error, qcel_v1.ComputeError):
+            error = qcel_v1.ComputeError(**error)
 
-    return_data = input_data.dict()
-    return_data.update(
-        error=error,
-        success=False,
-        return_result={
-            "energy": 0.0,
-            "gradient": np.zeros(input_data.molecule.geometry.shape),
-            "hessian": np.zeros(
-                (
-                    input_data.molecule.geometry.size,
-                    input_data.molecule.geometry.size,
-                )
-            ),
-            "properties": {},
-        }[input_data.driver],
-        properties={},
-        provenance=get_provenance(),
-    )
+        if not isinstance(input_data, qcel_v1.AtomicInput):
+            input_data = qcel_v1.AtomicInput(**input_data)
 
-    return qcel.models.AtomicResult(**return_data)
+        return_data = input_data.dict()
+        return_data.update(
+            error=error,
+            success=False,
+            return_result={
+                "energy": 0.0,
+                "gradient": np.zeros(input_data.molecule.geometry.shape),
+                "hessian": np.zeros(
+                    (
+                        input_data.molecule.geometry.size,
+                        input_data.molecule.geometry.size,
+                    )
+                ),
+                "properties": {},
+            }[input_data.driver],
+            properties={},
+            provenance=get_provenance(schema_version),
+        )
+        return qcel_v1.AtomicResult(**return_data)
+
+    elif schema_version == 2:
+        if not isinstance(error, qcel_v2.ComputeError):
+            error = qcel_v2.ComputeError(**error)
+
+        return qcel_v2.FailedOperation(input_data=input_data, error=error)
+
+    else:
+        raise ValueError(
+            f"Unsupported QCSchema version: {schema_version}. Only v1 and v2 are supported."
+        )
 
 
 class _Logger:
@@ -138,86 +213,120 @@ class _Logger:
         return self._buffer.getvalue()
 
 
-def run_schema(
-    input_data: Union[Dict[str, Any], qcel.models.AtomicInput]
-) -> qcel.models.AtomicResult:
+def run_schema(input_data):
     """Runs a QCSchema input through the QCEngine stack and returns a QCSchema result.
 
     Parameters
     ----------
     input_data : qcel.models.AtomicInput
-        A QCSchema input dictionary or model.
+        A QCSchema v1 or v2 input dictionary or model.
 
     Returns
     -------
     qcel.models.AtomicResult
-        A QCSchema result model.
+        A QCSchema v1 or v2 result model.
     """
-    if not isinstance(input_data, qcel.models.AtomicInput):
-        input_data = qcel.models.AtomicInput(**input_data)
+    if qcel_v2 is not None and isinstance(input_data, qcel_v2.AtomicInput):
+        atomic_input = input_data
+    elif qcel_v1 is not None and isinstance(input_data, qcel_v1.AtomicInput):
+        atomic_input = input_data
+    elif qcel_v2 is not None and input_data.get("specification"):
+        atomic_input = qcel_v2.AtomicInput(**input_data)
+    elif qcel_v1 is not None:
+        atomic_input = qcel_v1.AtomicInput(**input_data)
+    else:
+        raise ValueError(
+            "Input data is not a valid QCSchema AtomicInput for either v1 or v2."
+        )
 
-    if input_data.driver not in SUPPORTED_DRIVERS:
+    schema_version = atomic_input.schema_version
+    if schema_version == 1:
+        ret_data = atomic_input.dict()
+        input_keywords = atomic_input.keywords
+        input_method = atomic_input.model.method
+        input_basis = atomic_input.model.basis
+        input_driver = atomic_input.driver
+    elif schema_version == 2:
+        ret_data = {
+            "input_data": atomic_input,
+            "extras": {},
+            "molecule": atomic_input.molecule,
+        }
+        input_keywords = atomic_input.specification.keywords
+        input_method = atomic_input.specification.model.method
+        input_basis = atomic_input.specification.model.basis
+        input_driver = atomic_input.specification.driver
+    else:
+        raise ValueError(
+            f"Unsupported QCSchema version: {schema_version}. Only v1 and v2 are supported."
+        )
+
+    if input_driver not in SUPPORTED_DRIVERS:
         driver_name = (
-            input_data.driver.name
-            if hasattr(input_data.driver, "name")
-            else str(input_data.driver)
+            input_driver.name
+            if hasattr(input_driver, "name")
+            else str(input_driver)
         )
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            dict(
                 error_type="input_error",
                 error_message=f"Driver '{driver_name}' is not supported by tblite.",
             ),
+            schema_version,
         )
 
-    if input_data.model.method not in Calculator._loader:
+    if input_method not in Calculator._loader:
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            dict(
                 error_type="input_error",
-                error_message=f"Model '{input_data.model.method}' is not supported by tblite.",
+                error_message=f"Model '{input_method}' is not supported by tblite.",
             ),
+            schema_version,
         )
 
-    if input_data.model.basis is not None:
+    if input_basis is not None:
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            dict(
                 error_type="input_error",
                 error_message="Basis sets are not supported by tblite.",
             ),
+            schema_version,
         )
 
     keywords = {
         key: value
-        for key, value in input_data.keywords.items()
+        for key, value in input_keywords.items()
         if key in Calculator._setter
     }
     interaction = {
         key: value
-        for key, value in input_data.keywords.items()
+        for key, value in input_keywords.items()
         if key in Calculator._interaction
     }
     unknown_keywords = (
-        set(input_data.keywords) - set(keywords) - set(interaction)
+        set(input_keywords) - set(keywords) - set(interaction)
     )
     if unknown_keywords:
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            dict(
                 error_type="input_error",
                 error_message=f"Unknown keywords: {', '.join(unknown_keywords)}.",
             ),
+            schema_version,
         )
 
     logger = _Logger()
     try:
         calc = Calculator(
-            method=input_data.model.method,
-            numbers=input_data.molecule.atomic_numbers,
-            positions=input_data.molecule.geometry,
-            charge=input_data.molecule.molecular_charge,
-            uhf=input_data.molecule.molecular_multiplicity - 1,
+            method=input_method,
+            numbers=atomic_input.molecule.atomic_numbers,
+            positions=atomic_input.molecule.geometry,
+            charge=atomic_input.molecule.molecular_charge,
+            uhf=atomic_input.molecule.molecular_multiplicity - 1,
             color=False,
             logger=logger,
         )
@@ -231,7 +340,12 @@ def run_schema(
 
         result = calc.singlepoint().dict()
 
-        properties = qcel.models.AtomicResultProperties(
+        if schema_version == 1:
+            AtProp = qcel_v1.AtomicResultProperties
+        elif schema_version == 2:
+            AtProp = qcel_v2.AtomicProperties
+
+        properties = AtProp(
             return_energy=result["energy"],
             return_gradient=result["gradient"],
             calcinfo_natom=result["natoms"],
@@ -253,33 +367,37 @@ def run_schema(
                 "mulliken_charges": result["charges"],
                 "mayer_indices": result["bond-orders"],
             },
-        }[input_data.driver]
+        }[input_driver]
 
     except (TBLiteTypeError, TBLiteValueError) as e:
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            error = dict(
                 error_type="input_error",
                 error_message=str(e),
             ),
+            schema_version=schema_version,
         )
 
     except TBLiteRuntimeError as e:
         return get_error(
             input_data,
-            qcel.models.ComputeError(
+            error = dict(
                 error_type="execution_error",
                 error_message=str(e),
             ),
+            schema_version=schema_version,
         )
 
-    return_data = input_data.dict()
-    return_data.update(
+    ret_data.update(
         success=True,
         return_result=return_result,
         properties=properties,
-        provenance=get_provenance(),
+        provenance=get_provenance(schema_version),
         stdout=str(logger),
     )
 
-    return qcel.models.AtomicResult(**return_data)
+    if schema_version == 1:
+        return qcel_v1.AtomicResult(**ret_data)
+
+    return qcel_v2.AtomicResult(**ret_data)

--- a/python/tblite/qcschema.py
+++ b/python/tblite/qcschema.py
@@ -19,6 +19,12 @@ Integration with the `QCArchive infrastructure <https://qcarchive.molssi.org>`_.
 This module provides a function to run QCSchema input or QCElemental Atomic Input
 through the TBLite calculator and return the result as a QCElemental Atomic Result.
 
+If the QCElemental package is installed the ``tblite.qcschema`` module becomes
+importable and provides the ``run_schema`` function supporting QCSchema v1.
+If the QCElemental package is >=0.50.0, ``tblite.qcschema`` supports QCSchema v1
+and v2, returning whichever version was submitted. Note that Python 3.14+ only
+works with QCSchema v2 due to Pydantic restrictions.
+
 The model support the following methods:
 
 - **GFN2-xTB**: 

--- a/python/tblite/qcschema.py
+++ b/python/tblite/qcschema.py
@@ -348,7 +348,8 @@ def run_schema(input_data):
 
         if schema_version == 1:
             AtProp = qcel_v1.AtomicResultProperties
-        elif schema_version == 2:
+        else:
+            # schema_version == 2:
             AtProp = qcel_v2.AtomicProperties
 
         properties = AtProp(

--- a/python/tblite/test_qcschema.py
+++ b/python/tblite/test_qcschema.py
@@ -14,20 +14,31 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tblite.  If not, see <https://www.gnu.org/licenses/>.
 """Tests for the qcelemental interface."""
-from typing import Any
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pytest
 
 try:
-    import qcelemental as qcel
-    from qcelemental.models import AtomicInput, Molecule
-
     from tblite.qcschema import run_schema
+    import qcelemental
+    qcel_v1 = qcelemental.models
+    qcel_v2 = None
 except ModuleNotFoundError:
-    qcel = None
-    AtomicInput = dict
-    Molecule = dict
+    qcel_v1 = None
+    qcel_v2 = None
+
+v1_available = pytest.mark.skipif(
+    qcel_v1 is None, reason="QCSchema v1 not available for py314+"
+)
+v2_available = pytest.mark.skipif(
+    qcel_v2 is None, reason="QCSchema v2 not available in current QCElemental"
+)
+
+
+@pytest.fixture(params=[pytest.param(1, marks=v1_available), pytest.param(2, marks=v2_available)])
+def qcsk_version(request):
+    return request.param
 
 
 @pytest.fixture
@@ -37,8 +48,13 @@ def multiplicity(request) -> int:
 
 
 @pytest.fixture(params=["ala-xab"])
-def molecule(request, multiplicity: int) -> Molecule:
+def molecule(request, multiplicity: int, qcsk_version: int) -> "Molecule":
     """Get a molecule for testing."""
+    if qcsk_version == 1:
+        Molecule = qcel_v1.Molecule
+    elif qcsk_version == 2:
+        Molecule = qcel_v2.Molecule
+
     if request.param == "ala-xab":
         return Molecule(
             symbols=list("NHCHCCHHHOCCHHHONHCHHH"),
@@ -86,21 +102,59 @@ def method(request) -> str:
     return request.param
 
 
+def get_atomic_input(
+    version: int,
+    molecule: Dict[str, Any],
+    driver: str,
+    model: str,
+    keywords: Optional[Dict[str, Any]] = None,
+    qcel_object: bool = False,
+):
+    keywords = {} if keywords is None else keywords
+    spec = {
+        "driver": driver,
+        "model": model,
+        "keywords": keywords,
+    }
+
+    if version == 1:
+        input_data = {
+            "molecule": molecule,
+            **spec,
+        }
+        if qcel_object:
+            return qcel_v1.AtomicInput(**input_data)
+        return input_data
+
+    if version == 2:
+        input_data = {
+            "molecule": molecule,
+            "specification": spec,
+        }
+        if qcel_object:
+            return qcel_v2.AtomicInput(**input_data)
+        return input_data
+
+    raise ValueError(f"Unsupported version: {version}")
+
+
 @pytest.fixture()
-def atomic_input(molecule: Molecule, driver: str, method: str) -> AtomicInput:
+def atomic_input(molecule: "Molecule", driver: str, method: str, qcsk_version: int) -> "AtomicInput":
     """AtomicInput fixture."""
-    return AtomicInput(
+    return get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver=driver,
         model={"method": method},
         keywords={"spin-polarization": 1.0},
+        qcel_object=True,
     )
 
 
 @pytest.fixture()
-def return_result(molecule: Molecule, driver: str, method: str) -> Any:
+def return_result(molecule: "Molecule", driver: str, method: str) -> Any:
     """Return result fixture."""
-    if qcel is None:
+    if qcel_v1 is None and qcel_v2 is None:
         return None
 
     # fmt: off
@@ -249,9 +303,9 @@ def return_result(molecule: Molecule, driver: str, method: str) -> Any:
     # fmt: on
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 @pytest.mark.parametrize("multiplicity", [1, 3], indirect=True)
-def test_qcschema(atomic_input: AtomicInput, return_result: Any) -> None:
+def test_qcschema(atomic_input: "AtomicInput", return_result: Any) -> None:
     """Test qcschema interface."""
     atomic_result = run_schema(atomic_input)
 
@@ -272,20 +326,22 @@ def solvation(request) -> dict:
 
 
 @pytest.fixture()
-def atomic_input_solvation(molecule: Molecule, method: str, solvation: dict) -> AtomicInput:
+def atomic_input_solvation(molecule: "Molecule", method: str, solvation: dict, qcsk_version: int) -> "AtomicInput":
     """AtomicInput fixture."""
-    return AtomicInput(
+    return get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="energy",
         model={"method": method},
-        keywords=solvation
+        keywords=solvation,
+        qcel_object=False,
     )
 
 
 @pytest.fixture()
-def return_result_solvation(molecule: Molecule, method: str, solvation: dict) -> Any:
+def return_result_solvation(molecule: "Molecule", method: str, solvation: dict) -> Any:
     """Return result fixture."""
-    if qcel is None:
+    if qcel_v1 is None and qcel_v2 is None:
         return None
 
     # fmt: off
@@ -344,8 +400,8 @@ def return_result_solvation(molecule: Molecule, method: str, solvation: dict) ->
     # fmt: on
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_qcschema_solvation(atomic_input_solvation: AtomicInput, return_result_solvation: Any) -> None:
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_qcschema_solvation(atomic_input_solvation: "AtomicInput", return_result_solvation: Any) -> None:
     """Test qcschema interface."""
     atomic_result = run_schema(atomic_input_solvation)
 
@@ -353,10 +409,10 @@ def test_qcschema_solvation(atomic_input_solvation: AtomicInput, return_result_s
     assert pytest.approx(atomic_result.return_result) == return_result_solvation
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_unsupported_driver(molecule: Molecule):
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_unsupported_driver(molecule: "Molecule", qcsk_version: int):
     """Test unsupported driver name."""
-    atomic_inp = AtomicInput(
+    atomic_inp = get_atomic_input(qcsk_version,
         molecule=molecule,
         driver="hessian",
         model={"method": "GFN1-xTB"},
@@ -372,10 +428,12 @@ def test_unsupported_driver(molecule: Molecule):
     )
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_unsupported_method(molecule: Molecule):
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_unsupported_method(molecule: "Molecule", qcsk_version: int):
     """Test unsupported method name."""
-    atomic_inp = AtomicInput(
+
+    atomic_inp = get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="energy",
         model={"method": "GFN-xTB"},
@@ -391,10 +449,10 @@ def test_unsupported_method(molecule: Molecule):
     )
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_unsupported_basis(molecule: Molecule):
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_unsupported_basis(molecule: "Molecule", qcsk_version: int):
     """Test unsupported basis set."""
-    atomic_inp = AtomicInput(
+    atomic_inp = get_atomic_input(qcsk_version,
         molecule=molecule,
         driver="energy",
         model={"method": "GFN1-xTB", "basis": "def2-SVP"},
@@ -410,10 +468,10 @@ def test_unsupported_basis(molecule: Molecule):
     )
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_unsupported_keywords(molecule: Molecule):
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_unsupported_keywords(molecule: "Molecule", qcsk_version: int):
     """Test unsupported keywords."""
-    atomic_inp = AtomicInput(
+    atomic_inp = get_atomic_input(qcsk_version,
         molecule=molecule,
         driver="gradient",
         model={"method": "GFN1-xTB"},
@@ -427,10 +485,10 @@ def test_unsupported_keywords(molecule: Molecule):
     assert "Unknown keywords: unsupported" in atomic_result.error.error_message
 
 
-@pytest.mark.skipif(qcel is None, reason="requires qcelemental")
-def test_scf_not_converged(molecule: Molecule):
+@pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
+def test_scf_not_converged(molecule: "Molecule", qcsk_version: int):
     """Test unconverged SCF."""
-    atomic_inp = AtomicInput(
+    atomic_inp = get_atomic_input(qcsk_version,
         molecule=molecule,
         driver="gradient",
         model={"method": "GFN1-xTB"},

--- a/python/tblite/test_qcschema.py
+++ b/python/tblite/test_qcschema.py
@@ -20,10 +20,7 @@ import numpy as np
 import pytest
 
 try:
-    from tblite.qcschema import run_schema
-    import qcelemental
-    qcel_v1 = qcelemental.models
-    qcel_v2 = None
+    from tblite.qcschema import run_schema, qcel_v1, qcel_v2
 except ModuleNotFoundError:
     qcel_v1 = None
     qcel_v2 = None

--- a/python/tblite/test_qcschema.py
+++ b/python/tblite/test_qcschema.py
@@ -409,7 +409,8 @@ def test_qcschema_solvation(atomic_input_solvation: "AtomicInput", return_result
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 def test_unsupported_driver(molecule: "Molecule", qcsk_version: int):
     """Test unsupported driver name."""
-    atomic_inp = get_atomic_input(qcsk_version,
+    atomic_inp = get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="hessian",
         model={"method": "GFN1-xTB"},
@@ -428,7 +429,6 @@ def test_unsupported_driver(molecule: "Molecule", qcsk_version: int):
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 def test_unsupported_method(molecule: "Molecule", qcsk_version: int):
     """Test unsupported method name."""
-
     atomic_inp = get_atomic_input(
         qcsk_version,
         molecule=molecule,
@@ -449,7 +449,8 @@ def test_unsupported_method(molecule: "Molecule", qcsk_version: int):
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 def test_unsupported_basis(molecule: "Molecule", qcsk_version: int):
     """Test unsupported basis set."""
-    atomic_inp = get_atomic_input(qcsk_version,
+    atomic_inp = get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="energy",
         model={"method": "GFN1-xTB", "basis": "def2-SVP"},
@@ -468,7 +469,8 @@ def test_unsupported_basis(molecule: "Molecule", qcsk_version: int):
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 def test_unsupported_keywords(molecule: "Molecule", qcsk_version: int):
     """Test unsupported keywords."""
-    atomic_inp = get_atomic_input(qcsk_version,
+    atomic_inp = get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="gradient",
         model={"method": "GFN1-xTB"},
@@ -485,7 +487,8 @@ def test_unsupported_keywords(molecule: "Molecule", qcsk_version: int):
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
 def test_scf_not_converged(molecule: "Molecule", qcsk_version: int):
     """Test unconverged SCF."""
-    atomic_inp = get_atomic_input(qcsk_version,
+    atomic_inp = get_atomic_input(
+        qcsk_version,
         molecule=molecule,
         driver="gradient",
         model={"method": "GFN1-xTB"},


### PR DESCRIPTION
Expand QCSchema interface and testing to work with QCSchema v1 (pydantic v1 API) or v2 (pydantic v2 API and modified field layout). Version input is version returned. Note that because of pydantic constraints, v1 can only work with python <3.14, and v2 can only work with a QCElemental dependency currently in pre-release. Those details are encoded in import logic and pytest skipif.

CI works fine on my branch, and I don't have further downstream testing, so I'm removing the "Draft" constraint so you have flexibility, as I see you're up to tblite on the rebuild list over at c-f.