### PR TITLE
Wheel: Include subprojects in Python bindings building

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -61,7 +61,7 @@ jobs:
         git config user.name "dummy"
         git subtree add --prefix python/subprojects/tblite . HEAD
     - run: |
-        python -m build python/ --sdist --outdir . -n
+        python -m build python/ --sdist --outdir . -n -Cdist-args="--include-subprojects"
     - uses: actions/upload-artifact@v4
       with:
         name: tblite-python-sdist


### PR DESCRIPTION
For the convenience of building offline.