### PR TITLE
Allow setting smooth cutoffs when constructing calculator

### DIFF
--- a/app/cli.f90
+++ b/app/cli.f90
@@ -27,6 +27,7 @@ module tblite_cli
    use tblite_solvation, only : solvation_input, cpcm_input, alpb_input, &
       & cds_input, shift_input, solvent_data, get_solvent_data, solution_state, born_kernel
    use tblite_version, only : get_tblite_version
+   use tblite_xtb_calculator, only : xtb_config
    implicit none
    private
 
@@ -88,6 +89,8 @@ module tblite_cli
       logical :: spin_polarized = .false.
       !> Algorithm for electronic solver
       integer :: solver = lapack_algorithm%gvd
+      !> Configuration for xtb calculator
+      type(xtb_config) :: cfg = xtb_config()
    end type run_config
 
    !> Configuration for evaluating tight binding model on input structure
@@ -253,7 +256,7 @@ subroutine get_run_arguments(config, list, start, error)
 
    integer :: iarg, narg
    logical :: getopts
-   character(len=:), allocatable :: arg
+   character(len=:), allocatable :: arg, sec
    logical :: solvent_not_found, parametrized_solvation
    logical, allocatable :: alpb
    integer, allocatable :: kernel, sol_state
@@ -342,6 +345,33 @@ subroutine get_run_arguments(config, list, start, error)
       case("--guess")
          iarg = iarg + 1
          call list%get(iarg, config%guess)
+
+      case("--config")
+         iarg = iarg + 1
+         call list%get(iarg, arg)
+         if (.not.allocated(arg)) then
+            call fatal_error(error, "Missing argument for config")
+            exit
+         end if
+
+         block
+            integer :: ieq
+
+            ieq = index(arg, "=")
+            if (ieq == 0) then
+               call fatal_error(error, "Invalid format for config argument, expected key=value")
+               exit
+            end if
+            sec = arg(ieq+1:)
+
+            select case(arg(1:ieq-1))
+            case("smooth_cutoff")
+               call get_argument_as_real(sec, config%cfg%smooth_cutoff, error)
+            case default
+               call fatal_error(error, "Unknown configuration key '"//arg(1:ieq-1)//"'")
+               exit
+            end select
+         end block
 
       case("--restart")
          iarg = iarg + 1

--- a/app/cli_help.f90
+++ b/app/cli_help.f90
@@ -116,6 +116,9 @@ module tblite_cli_help
       "      --etemp <real>       Electronic temperature for calculation (Default: 300K)"//nl//&
       "      --guess <name>       Guess for the initial populations, possible options:"//nl//&
       "                           sad (default), eeq, eeqbc, ceh (Charge-Extended Hückel method)"//nl//&
+      "      --config <key>=<value>"//nl//&
+      "                           Set configuration key to value, possible keys are:"//nl//&
+      "                           smooth_cutoff (default: 0.05)"//nl//&
       "      --restart [<file>]   Restart calculation from previous run"//nl//&
       "                           File name for restart file is optional,"//nl//&
       "                           (Default: tblite-restart.npz)"//nl//&
@@ -165,7 +168,7 @@ module tblite_cli_help
 
    !> Help text for guess command
    character(len=*), parameter :: help_text_guess = &
-      "Usage: "//prog_name//" [guess] [options] <input>"//nl//&
+      "Usage: "//prog_name//" guess [options] <input>"//nl//&
       ""//nl//&
       "Execute only the atomic charge / density guess."//nl//&
       "Prints the initializing charges and dipole moments."//nl//&

--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -134,7 +134,7 @@ subroutine run_main(config, error)
    if (allocated(config%param)) then
       call param%load(config%param, error)
       if (.not. allocated(error)) then
-         call new_xtb_calculator(calc, mol, param, error)
+         call new_xtb_calculator(calc, mol, param, error, config%cfg)
       end if
    else
       method = "gfn2"
@@ -143,11 +143,11 @@ subroutine run_main(config, error)
       case default
          call fatal_error(error, "Unknown method '"//method//"' requested")
       case("gfn2")
-         call new_gfn2_calculator(calc, mol, error)
+         call new_gfn2_calculator(calc, mol, error, config%cfg)
       case("gfn1")
-         call new_gfn1_calculator(calc, mol, error)
+         call new_gfn1_calculator(calc, mol, error, config%cfg)
       case("ipea1")
-         call new_ipea1_calculator(calc, mol, error)
+         call new_ipea1_calculator(calc, mol, error, config%cfg)
       end select
    end if
    if (allocated(error)) return

--- a/config/meson.build
+++ b/config/meson.build
@@ -163,7 +163,7 @@ lib_deps += multicharge_dep
 # Create DFT-D4 library as subproject
 dftd4_dep = dependency(
   'dftd4',
-  version: '>=4.0.0',
+  version: '>=4.2.0',
   fallback: ['dftd4', 'dftd4_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )
@@ -181,7 +181,7 @@ lib_deps += multicharge_dep
 # Create DFT-D3 library as subproject
 sdftd3_dep = dependency(
   's-dftd3',
-  version: '>=0.6.0',
+  version: '>=1.4.0',
   fallback: ['s-dftd3', 'sdftd3_dep'],
   default_options: ['default_library=static', 'api=false', 'python=false'],
 )

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,8 +20,9 @@ import sys
 
 _dir = os.path.abspath(os.path.dirname(__file__))
 
-import tblite
 from tblite.library import get_version
+
+import tblite
 
 project = "tblite"
 author = "Sebastian Ehlert"

--- a/include/tblite/calculator.h
+++ b/include/tblite/calculator.h
@@ -45,43 +45,57 @@ typedef enum {
 /// Single point calculator
 typedef struct _tblite_calculator* tblite_calculator;
 
+/// Configuration for calculator setup
+typedef struct {
+   /// Smooth cutoff for the Fermi function in the GFN-xTB method (in Hartree)
+   double smooth_cutoff;
+} tblite_xtb_config;
+
 /// Construct calculator with GFN2-xTB parametrisation loaded
 ///
 /// @param ctx: Context handle
 /// @param mol: Molecular structure data
+/// @param config: Configuration for calculator setup
 /// @return New calculator instance
 TBLITE_API_ENTRY tblite_calculator TBLITE_API_CALL
 tblite_new_gfn2_calculator(tblite_context ctx,
-                           tblite_structure mol);
+                           tblite_structure mol,
+                           tblite_xtb_config* config);
 
 /// Construct calculator with GFN1-xTB parametrisation loaded
 ///
 /// @param ctx: Context handle
 /// @param mol: Molecular structure data
+/// @param config: Configuration for calculator setup
 /// @return New calculator instance
 TBLITE_API_ENTRY tblite_calculator TBLITE_API_CALL
 tblite_new_gfn1_calculator(tblite_context ctx,
-                           tblite_structure mol);
+                           tblite_structure mol,
+                           tblite_xtb_config* config);
 
 /// Construct calculator with IPEA1-xTB parametrisation loaded
 ///
 /// @param ctx: Context handle
 /// @param mol: Molecular structure data
+/// @param config: Configuration for calculator setup
 /// @return New calculator instance
 TBLITE_API_ENTRY tblite_calculator TBLITE_API_CALL
 tblite_new_ipea1_calculator(tblite_context ctx,
-                            tblite_structure mol);
+                            tblite_structure mol,
+                            tblite_xtb_config* config);
 
 /// Construct calculator from parametrization records
 ///
 /// @param ctx: Context handle
 /// @param mol: Molecular structure data
+/// @param config: Configuration for calculator setup
 /// @return New calculator instance
 /// @param param: Parametrization records
 TBLITE_API_ENTRY tblite_calculator TBLITE_API_CALL
 tblite_new_xtb_calculator(tblite_context ctx,
                           tblite_structure mol,
-                          tblite_param param);
+                          tblite_param param,
+                          tblite_xtb_config* config);
 
 /// Delete calculator
 ///

--- a/man/tblite-run.1.adoc
+++ b/man/tblite-run.1.adoc
@@ -50,6 +50,10 @@ Supported geometry input formats are:
      Guess for the initial populations, possible options:
      _sad_ (default), _eeq_, _eeqbc_, and _ceh_.
 
+*--config* _key=value_::
+     Set configuration key to value, possible keys are:
+     _smooth\_cutoff_ (default: 0.05)
+
 *--restart* [_string_]::
      Restart calculation from previous run.
      Provide the name of the restart file (default 'tblite-restart.npz')

--- a/python/tblite/ase.py
+++ b/python/tblite/ase.py
@@ -124,6 +124,7 @@ class TBLite(ase.calculators.calculator.Calculator):
      solvation                None              Solvation model to use (see below for details)
      cache_api                True              Reuse generate API objects (recommended)
      verbosity                1                 Set verbosity of printout
+     xtb_config               None              Additional configuration for the API calculator (dict)
     ======================== ================= ====================================================
 
     Solvation models are supported by passing a tuple to the *solvation* keyword.
@@ -202,6 +203,7 @@ class TBLite(ase.calculators.calculator.Calculator):
         "electronic_temperature": 300.0,
         "cache_api": True,
         "verbosity": 1,
+        "xtb_config": None,
     }
 
     _res = None
@@ -251,6 +253,7 @@ class TBLite(ase.calculators.calculator.Calculator):
             or "electric_field" in changed_parameters
             or "spin_polarization" in changed_parameters
             or "solvation" in changed_parameters
+            or "xtb_config" in changed_parameters
         ):
             self._xtb = None
             self._res = None
@@ -270,7 +273,9 @@ class TBLite(ase.calculators.calculator.Calculator):
                 self._xtb.set("max-iter", self.parameters.max_iterations)
 
             if "initial_guess" in changed_parameters:
-                self._xtb.set("guess", {"sad": 0, "eeq": 1, "eeqbc": 2}[self.parameters.guess])
+                self._xtb.set(
+                    "guess", {"sad": 0, "eeq": 1, "eeqbc": 2}[self.parameters.guess]
+                )
 
             if "mixer_damping" in changed_parameters:
                 self._xtb.set("mixer-damping", self.parameters.mixer_damping)
@@ -358,7 +363,9 @@ class TBLite(ase.calculators.calculator.Calculator):
 
         if not properties:
             properties = ["energy"]
-        ase.calculators.calculator.Calculator.calculate(self, atoms, properties, system_changes)
+        ase.calculators.calculator.Calculator.calculate(
+            self, atoms, properties, system_changes
+        )
 
         self._check_api_calculator(system_changes)
 
@@ -404,6 +411,7 @@ def _create_api_calculator(
             _uhf,
             _cell / Bohr,
             _periodic,
+            xtb_config=parameters.xtb_config,
         )
         calc.set("accuracy", parameters.accuracy)
         calc.set(
@@ -434,16 +442,24 @@ def _create_api_calculator(
     return calc
 
 
-def _get_charge(atoms: ase.Atoms, parameters: ase.calculators.calculator.Parameters) -> int:
+def _get_charge(
+    atoms: ase.Atoms, parameters: ase.calculators.calculator.Parameters
+) -> int:
     """
     Get the total charge of the system.
     If no charge is provided, the total charge of the system is calculated
     by summing the initial charges of all atoms.
     """
-    return atoms.get_initial_charges().sum() if parameters.charge is None else parameters.charge
+    return (
+        atoms.get_initial_charges().sum()
+        if parameters.charge is None
+        else parameters.charge
+    )
 
 
-def _get_uhf(atoms: ase.Atoms, parameters: ase.calculators.calculator.Parameters) -> int:
+def _get_uhf(
+    atoms: ase.Atoms, parameters: ase.calculators.calculator.Parameters
+) -> int:
     """
     Get the number of unpaired electrons.
     If no multiplicity is provided, the number of unpaired electrons

--- a/python/tblite/interface.py
+++ b/python/tblite/interface.py
@@ -20,9 +20,10 @@ of the library in actual workflows than the low-level access provided in the
 CFFI generated wrappers.
 """
 
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
+
 from . import library
 from .exceptions import TBLiteRuntimeError, TBLiteValueError
 
@@ -85,9 +86,7 @@ class Structure:
             raise TBLiteValueError("Expected tripels of cartesian coordinates")
 
         if 3 * numbers.size != positions.size:
-            raise TBLiteValueError(
-                "Dimension missmatch between numbers and positions"
-            )
+            raise TBLiteValueError("Dimension missmatch between numbers and positions")
 
         self._natoms = len(numbers)
         _numbers = np.ascontiguousarray(numbers, dtype="i4")
@@ -344,7 +343,7 @@ class Result:
             if the saving fails
         """
         library.save_wavefunction(self._res, filename)
-    
+
     def load(self, filename: str) -> None:
         """
         Load a result container from a file. The format is compatible with the
@@ -499,10 +498,10 @@ class Calculator(Structure):
         "gb-solvation": library.new_gb_solvation,
     }
     _post_processing = {
-        "bond-orders" : "bond-orders",
-        "molecular-multipoles" : "molmom",
-        "xtbml" : "xtbml",
-        "xtbml_xyz" : "xtbml_xyz"
+        "bond-orders": "bond-orders",
+        "molecular-multipoles": "molmom",
+        "xtbml": "xtbml",
+        "xtbml_xyz": "xtbml_xyz",
     }
 
     def __init__(
@@ -514,6 +513,7 @@ class Calculator(Structure):
         uhf: Optional[int] = None,
         lattice: Optional[np.ndarray] = None,
         periodic: Optional[np.ndarray] = None,
+        xtb_config: Optional[Dict[str, Any]] = None,
         **context_kwargs,
     ):
         """
@@ -524,16 +524,14 @@ class Calculator(Structure):
         TBLiteValueError
             on invalid input, like incorrect shape / type of the passed arrays
         """
-        Structure.__init__(
-            self, numbers, positions, charge, uhf, lattice, periodic
-        )
+        Structure.__init__(self, numbers, positions, charge, uhf, lattice, periodic)
 
         self._ctx = library.new_context(**context_kwargs)
         if method not in self._loader:
             raise TBLiteValueError(
                 f"Method '{method}' is not available for this calculator"
             )
-        self._calc = self._loader[method](self._ctx, self._mol)
+        self._calc = self._loader[method](self._ctx, self._mol, xtb_config)
         self._method = method
 
     def set(self, attribute: str, value) -> None:
@@ -642,11 +640,8 @@ class Calculator(Structure):
                 f"Attribute '{attribute}' is not supported in this calculator"
             )
         return self._getter[attribute](self._ctx, self._calc)
-        
 
-    def singlepoint(
-        self, res: Optional[Result] = None, copy: bool = False
-    ) -> Result:
+    def singlepoint(self, res: Optional[Result] = None, copy: bool = False) -> Result:
         """
         Perform actual single point calculation in the library backend.
         The output of the library will be forwarded to the standard output.
@@ -706,9 +701,7 @@ ELEMENT_SYMBOLS = [
 ]
 # fmt: on
 
-SYMBOL_TO_NUMBER = {
-    symbol: number + 1 for number, symbol in enumerate(ELEMENT_SYMBOLS)
-}
+SYMBOL_TO_NUMBER = {symbol: number + 1 for number, symbol in enumerate(ELEMENT_SYMBOLS)}
 
 
 def symbols_to_numbers(symbols: List[str]) -> List[int]:

--- a/python/tblite/library.py
+++ b/python/tblite/library.py
@@ -22,16 +22,14 @@ also provides some FFI based wappers for memory handling.
 
 import functools
 import sys
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
 try:
     from ._libtblite import ffi, lib
 except ImportError as e:
-    raise ImportError(
-        "tblite C extension unimportable, cannot use C-API"
-    ) from e
+    raise ImportError("tblite C extension unimportable, cannot use C-API") from e
 
 from .exceptions import TBLiteRuntimeError, TBLiteValueError
 
@@ -125,9 +123,7 @@ def new_context(color: bool = True, logger: Callable[[str], None] = print):
     """Create new tblite context handler object"""
     ctx = ffi.gc(lib.tblite_new_context(), _delete_context)
     handle = ffi.new_handle(logger)
-    context_check(lib.tblite_set_context_logger)(
-        ctx, lib.logger_callback, handle
-    )
+    context_check(lib.tblite_set_context_logger)(ctx, lib.logger_callback, handle)
     if color and sys.stdout.isatty():
         context_check(lib.tblite_set_context_color)(ctx, 1)
     return ctx, handle
@@ -381,9 +377,7 @@ get_orbital_coefficients = _get_ao_matrix(
 )
 get_density_matrix = _get_ao_matrix(lib.tblite_get_result_density_matrix, True)
 get_overlap_matrix = _get_ao_matrix(lib.tblite_get_result_overlap_matrix, False)
-get_hamiltonian_matrix = _get_ao_matrix(
-    lib.tblite_get_result_hamiltonian_matrix, False
-)
+get_hamiltonian_matrix = _get_ao_matrix(lib.tblite_get_result_hamiltonian_matrix, False)
 
 
 def _delete_calculator(calc) -> None:
@@ -394,28 +388,59 @@ def _delete_calculator(calc) -> None:
 
 
 @context_check
-def new_gfn2_calculator(ctx, mol):
+def new_gfn2_calculator(ctx, mol, cfg=None):
     """Create new tblite calculator loaded with GFN2-xTB parametrization data"""
-    return ffi.gc(lib.tblite_new_gfn2_calculator(ctx, mol), _delete_calculator)
+    return ffi.gc(
+        lib.tblite_new_gfn2_calculator(ctx, mol, tblite_xtb_config(cfg)),
+        _delete_calculator,
+    )
 
 
 @context_check
-def new_gfn1_calculator(ctx, mol):
+def new_gfn1_calculator(ctx, mol, cfg=None):
     """Create new tblite calculator loaded with GFN1-xTB parametrization data"""
-    return ffi.gc(lib.tblite_new_gfn1_calculator(ctx, mol), _delete_calculator)
+    return ffi.gc(
+        lib.tblite_new_gfn1_calculator(ctx, mol, tblite_xtb_config(cfg)),
+        _delete_calculator,
+    )
 
 
 @context_check
-def new_ipea1_calculator(ctx, mol):
+def new_ipea1_calculator(ctx, mol, cfg=None):
     """Create new tblite calculator loaded with IPEA1-xTB parametrization data"""
-    return ffi.gc(lib.tblite_new_ipea1_calculator(ctx, mol), _delete_calculator)
+    return ffi.gc(
+        lib.tblite_new_ipea1_calculator(ctx, mol, tblite_xtb_config(cfg)),
+        _delete_calculator,
+    )
 
 
 @context_check
-def new_xtb_calculator(ctx, mol, param):
+def new_xtb_calculator(ctx, mol, param, cfg=None):
     """Create new tblite calculator from parametrization records"""
     return ffi.gc(
-        lib.tblite_new_xtb_calculator(ctx, mol, param), _delete_calculator
+        lib.tblite_new_xtb_calculator(ctx, mol, param, tblite_xtb_config(cfg)),
+        _delete_calculator,
+    )
+
+
+def tblite_xtb_config(config: Optional[Dict[str, Any]] = None):
+    if config is None:
+        return ffi.NULL
+
+    SUPPORTED_KEYS = {"smooth_cutoff": 0.05}
+
+    if set(config.keys()) - set(SUPPORTED_KEYS.keys()):
+        raise TBLiteValueError(
+            f"Unsupported configuration keys: {set(config.keys()) - set(SUPPORTED_KEYS.keys())}. "
+            f"Supported keys are: {SUPPORTED_KEYS.keys()}."
+        )
+
+    return ffi.new(
+        "tblite_xtb_config *",
+        {
+            key: config.get(key, default)
+            for key, default in SUPPORTED_KEYS.items()
+        }
     )
 
 
@@ -451,9 +476,7 @@ def get_post_processing_dict(res) -> Dict[str, np.ndarray]:
         _dim1 = ffi.new("int*")
         _dim2 = ffi.new("int*")
         _dim3 = ffi.new("int*")
-        error_check(lib.tblite_get_array_size_index)(
-            _dict, _index, _dim1, _dim2, _dim3
-        )
+        error_check(lib.tblite_get_array_size_index)(_dict, _index, _dim1, _dim2, _dim3)
         if _dim3[0] == 0:
             if _dim2[0] == 0:
                 _array = np.zeros((_dim1[0],))
@@ -466,9 +489,7 @@ def get_post_processing_dict(res) -> Dict[str, np.ndarray]:
             _dict, _index, ffi.cast("double*", _array.ctypes.data)
         )
         _message = ffi.new("char[]", 512)
-        error_check(lib.tblite_get_label_entry_index)(
-            _dict, _index, _message, ffi.NULL
-        )
+        error_check(lib.tblite_get_label_entry_index)(_dict, _index, _message, ffi.NULL)
         label = ffi.string(_message).decode()
         _dict_py[label] = _array
     return _dict_py
@@ -498,16 +519,10 @@ def get_calculator_orbital_map(ctx, calc) -> np.ndarray:
 
 set_calculator_max_iter = context_check(lib.tblite_set_calculator_max_iter)
 set_calculator_accuracy = context_check(lib.tblite_set_calculator_accuracy)
-set_calculator_mixer_damping = context_check(
-    lib.tblite_set_calculator_mixer_damping
-)
+set_calculator_mixer_damping = context_check(lib.tblite_set_calculator_mixer_damping)
 set_calculator_guess = context_check(lib.tblite_set_calculator_guess)
-set_calculator_temperature = context_check(
-    lib.tblite_set_calculator_temperature
-)
-set_calculator_save_integrals = context_check(
-    lib.tblite_set_calculator_save_integrals
-)
+set_calculator_temperature = context_check(lib.tblite_set_calculator_temperature)
+set_calculator_save_integrals = context_check(lib.tblite_set_calculator_save_integrals)
 
 
 @context_check
@@ -587,9 +602,7 @@ def new_gb_solvation(ctx, mol, calc, epsilon: float, born: str):
 
 def new_cpcm_solvation(ctx, mol, calc, epsilon: float):
     """Create new tblite CPCM solvation object"""
-    return error_check(lib.tblite_new_cpcm_solvation_epsilon)(
-        mol, float(epsilon)
-    )
+    return error_check(lib.tblite_new_cpcm_solvation_epsilon)(mol, float(epsilon))
 
 
 @context_check

--- a/python/tblite/qcschema.py
+++ b/python/tblite/qcschema.py
@@ -71,7 +71,7 @@ Supported keywords are:
 
 import sys
 from io import StringIO
-from typing import Any, Dict, Literal, overload, Union
+from typing import Any, Dict, Literal, Union, overload
 
 import numpy as np
 
@@ -110,37 +110,43 @@ SUPPORTED_DRIVERS = {
 if qcel_v1 is not None:
 
     @overload
-    def get_provenance(schema_version: Literal[1]) -> "qcel_v1.Provenance": ...
+    def get_provenance(schema_version: Literal[1]) -> "qcel_v1.Provenance":
+        ...
 
     @overload
     def get_error(
         input_data: "qcel_v1.AtomicInput",
         error: Union[Dict[str, Any], "qcel_v1.ComputeError"],
         schema_version: int,
-    ) -> "qcel_v1.AtomicResult": ...
+    ) -> "qcel_v1.AtomicResult":
+        ...
 
     @overload
     def run_schema(
         input_data: Union[Dict[str, Any], "qcel_v1.AtomicInput"],
-    ) -> Union["qcel_v1.AtomicResult", "qcel_v1.FailedOperation"]: ...
+    ) -> Union["qcel_v1.AtomicResult", "qcel_v1.FailedOperation"]:
+        ...
 
 
 if qcel_v2 is not None:
 
     @overload
-    def get_provenance(schema_version: Literal[2]) -> "qcel_v2.Provenance": ...
+    def get_provenance(schema_version: Literal[2]) -> "qcel_v2.Provenance":
+        ...
 
     @overload
     def get_error(
         input_data: "qcel_v2.AtomicInput",
         error: Union[Dict[str, Any], "qcel_v2.ComputeError"],
         schema_version: int,
-    ) -> "qcel_v2.FailedOperation": ...
+    ) -> "qcel_v2.FailedOperation":
+        ...
 
     @overload
     def run_schema(
         input_data: Union[Dict[str, Any], "qcel_v2.AtomicInput"],
-    ) -> Union["qcel_v2.AtomicResult", "qcel_v2.FailedOperation"]: ...
+    ) -> Union["qcel_v2.AtomicResult", "qcel_v2.FailedOperation"]:
+        ...
 
 
 def get_provenance(schema_version: Literal[1, 2]):
@@ -269,9 +275,7 @@ def run_schema(input_data):
 
     if input_driver not in SUPPORTED_DRIVERS:
         driver_name = (
-            input_driver.name
-            if hasattr(input_driver, "name")
-            else str(input_driver)
+            input_driver.name if hasattr(input_driver, "name") else str(input_driver)
         )
         return get_error(
             input_data,
@@ -303,18 +307,14 @@ def run_schema(input_data):
         )
 
     keywords = {
-        key: value
-        for key, value in input_keywords.items()
-        if key in Calculator._setter
+        key: value for key, value in input_keywords.items() if key in Calculator._setter
     }
     interaction = {
         key: value
         for key, value in input_keywords.items()
         if key in Calculator._interaction
     }
-    unknown_keywords = (
-        set(input_keywords) - set(keywords) - set(interaction)
-    )
+    unknown_keywords = set(input_keywords) - set(keywords) - set(interaction)
     if unknown_keywords:
         return get_error(
             input_data,
@@ -359,9 +359,7 @@ def run_schema(input_data):
             calcinfo_nbasis=result["norbitals"],
             calcinfo_nmo=result["norbitals"],
             scf_dipole_moment=result["dipole"],
-            scf_quadrupole_moment=result["quadrupole"][
-                [0, 1, 3, 1, 2, 4, 3, 4, 5]
-            ],
+            scf_quadrupole_moment=result["quadrupole"][[0, 1, 3, 1, 2, 4, 3, 4, 5]],
             scf_total_energy=result["energy"],
             scf_total_gradient=result["gradient"],
         )
@@ -379,7 +377,7 @@ def run_schema(input_data):
     except (TBLiteTypeError, TBLiteValueError) as e:
         return get_error(
             input_data,
-            error = dict(
+            error=dict(
                 error_type="input_error",
                 error_message=str(e),
             ),
@@ -389,7 +387,7 @@ def run_schema(input_data):
     except TBLiteRuntimeError as e:
         return get_error(
             input_data,
-            error = dict(
+            error=dict(
                 error_type="execution_error",
                 error_message=str(e),
             ),

--- a/python/tblite/test_ase.py
+++ b/python/tblite/test_ase.py
@@ -197,7 +197,7 @@ def test_gfn1_xtb_3d():
         ]
     )
 
-    atoms.calc = TBLite(method="GFN1-xTB")
+    atoms.calc = TBLite(method="GFN1-xTB", xtb_config={"smooth_cutoff": 0.0})
     assert atoms.pbc.all()
 
     assert approx(atoms.get_potential_energy(), abs=thr) == -1257.0801067985549
@@ -261,7 +261,7 @@ def test_spgfn1_xtb():
 @pytest.mark.skipif(ase is None, reason="requires ase")
 def test_solvation_gfn2_xtb_cpcm():
     """Test CPCM solvation with GFN2-xTB"""
-    thr = 5.0e-5 # currently loose testing due to non-variational CPCM
+    thr = 5.0e-5  # currently loose testing due to non-variational CPCM
 
     atoms = get_crcp2()
 
@@ -270,7 +270,7 @@ def test_solvation_gfn2_xtb_cpcm():
 
     atoms.calc.set(cpcm_solvation=7.0)
     assert approx(atoms.get_potential_energy(), abs=thr) == -773.6978494954839
-                                                            
+
 
 @pytest.mark.skipif(ase is None, reason="requires ase")
 def test_solvation_gfn2_xtb_alpb():

--- a/python/tblite/test_interface.py
+++ b/python/tblite/test_interface.py
@@ -19,7 +19,6 @@ from tempfile import NamedTemporaryFile
 
 import numpy as np
 from pytest import approx, raises
-
 from tblite.exceptions import TBLiteRuntimeError, TBLiteValueError
 from tblite.interface import Calculator, Result, symbols_to_numbers
 
@@ -118,9 +117,7 @@ def get_ala(conf):
 
 def get_crcp2():
     """Get structure for CrCP2"""
-    numbers = np.array(
-        [24, 6, 6, 6, 6, 6, 1, 1, 1, 1, 1, 6, 6, 6, 1, 6, 1, 6, 1, 1, 1]
-    )
+    numbers = np.array([24, 6, 6, 6, 6, 6, 1, 1, 1, 1, 1, 6, 6, 6, 1, 6, 1, 6, 1, 1, 1])
     positions = np.array(
         [
             [+0.00000000000000, +0.00000000000000, -0.06044684528305],
@@ -519,6 +516,7 @@ def test_post_processing_api():
     wbo_sp = calc.singlepoint().get("bond-orders")
     assert wbo_sp.ndim == 3
 
+
 def test_xtbml_api():
     numbers, positions = get_crcp2()
     calc = Calculator("GFN1-xTB", numbers, positions)
@@ -532,29 +530,31 @@ def test_xtbml_api():
     dict_xtbml = res.dict()
     dict_xtbml = dict_xtbml.get("post-processing-dict")
     assert len(dict_xtbml.keys()) == 39
-    
-    toml_inp = ["[post-processing.xtbml] \n",
-                "geometry = false \n",
-                "density = true \n",
-                "orbital = true \n",
-                "energy = false \n", 
-                "convolution = true\n",
-                "a = [1.0, 1.2]\n",
-                "tensorial-output = true"]
-    
+
+    toml_inp = [
+        "[post-processing.xtbml] \n",
+        "geometry = false \n",
+        "density = true \n",
+        "orbital = true \n",
+        "energy = false \n",
+        "convolution = true\n",
+        "a = [1.0, 1.2]\n",
+        "tensorial-output = true",
+    ]
+
     with open("xtbml.toml", "w") as f:
         f.writelines(toml_inp)
-        
+
     calc = Calculator("GFN1-xTB", numbers, positions)
     calc.add("xtbml.toml")
-    
+
     res = calc.singlepoint()
     dict_ = res.get("post-processing-dict")
-    
+
     assert dict_.get("CN_A") is None
 
     assert len(dict_.keys()) == 130
-    
+
 
 def test_solvation_gfn2_cpcm():
     """Test CPCM solvation with GFN2-xTB"""
@@ -637,7 +637,8 @@ def test_solvation_gfn2_gb():
     calc.add("gb-solvation", 7.0, "still")
 
     energy = calc.singlepoint().get("energy")
-    assert energy == approx(-28.43676829542, abs=THR) 
+    assert energy == approx(-28.43676829542, abs=THR)
+
 
 def test_solvation_gfn1_alpb():
     """Test ALPB solvation with GFN1-xTB"""
@@ -667,7 +668,6 @@ def test_result_getter():
 
     with raises(ValueError, match="Attribute 'unknown' is not available"):
         res.get("unknown")
-    
 
 
 def test_result_setter():
@@ -706,9 +706,7 @@ def test_gfn1_logging():
 
     logger = Logger("test")
 
-    calc = Calculator(
-        "GFN1-xTB", numbers, positions, color=False, logger=logger.info
-    )
+    calc = Calculator("GFN1-xTB", numbers, positions, color=False, logger=logger.info)
     res = calc.singlepoint()
 
     assert res.get("energy") == approx(-34.980794815805446, abs=THR)
@@ -716,9 +714,7 @@ def test_gfn1_logging():
     def broken_logger(message: str) -> None:
         raise NotImplementedError("This logger is broken")
 
-    calc = Calculator(
-        "GFN1-xTB", numbers, positions, color=False, logger=broken_logger
-    )
+    calc = Calculator("GFN1-xTB", numbers, positions, color=False, logger=broken_logger)
     with raises(TBLiteRuntimeError):
         calc.singlepoint()
 
@@ -764,13 +760,17 @@ def test_numbers():
 def test_spin_polarized_restart():
     # Use a small open-shell system (e.g., NO) in Bohr
     numbers = np.array([7, 8], dtype=np.int32)
-    positions = np.array([
-        [0.0, 0.0, -1.1],
-        [0.0, 0.0,  1.1],
-    ], dtype=float)
+    positions = np.array(
+        [
+            [0.0, 0.0, -1.1],
+            [0.0, 0.0, 1.1],
+        ],
+        dtype=float,
+    )
 
     # Capture output to count iterations
     log = []
+
     def logger(msg):
         log.append(msg)
 
@@ -778,11 +778,11 @@ def test_spin_polarized_restart():
     calc = Calculator("GFN2-xTB", numbers, positions, uhf=1, logger=logger)
     calc.add("spin-polarization", 1.0)
     calc.set("verbosity", 1)
-    
+
     # Full run
     res_full = calc.singlepoint()
     energy_full = res_full.get("energy")
-    
+
     # Clear log for restart run
     log.clear()
 
@@ -790,17 +790,17 @@ def test_spin_polarized_restart():
     res_restart_wfn = Result(res_full)
     res_restart_wfn = calc.singlepoint(res_restart_wfn)
     energy_restart_wfn = res_restart_wfn.get("energy")
-    
+
     # Count iterations (lines starting with an integer index)
     iterations = 0
     for line in log:
         parts = line.strip().split()
         if len(parts) > 0 and parts[0].isdigit():
             iterations += 1
-            
+
     # Check energy consistency
     assert abs(energy_full - energy_restart_wfn) < 1e-8
-    
+
     # Verify iteration count (should be very low, e.g., <= 3)
     # Ideally 1 or 2 if restart is perfect
     assert iterations <= 3, f"Restart took {iterations} iterations, expected <= 3"

--- a/python/tblite/test_qcschema.py
+++ b/python/tblite/test_qcschema.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 try:
-    from tblite.qcschema import run_schema, qcel_v1, qcel_v2
+    from tblite.qcschema import qcel_v1, qcel_v2, run_schema
 except ModuleNotFoundError:
     qcel_v1 = None
     qcel_v2 = None
@@ -33,7 +33,9 @@ v2_available = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(params=[pytest.param(1, marks=v1_available), pytest.param(2, marks=v2_available)])
+@pytest.fixture(
+    params=[pytest.param(1, marks=v1_available), pytest.param(2, marks=v2_available)]
+)
 def qcsk_version(request):
     return request.param
 
@@ -81,7 +83,7 @@ def molecule(request, multiplicity: int, qcsk_version: int) -> "Molecule":
                     [-1.32658751691561, -0.95404596601807, +4.30967630773603],
                 ]
             ),
-            molecular_multiplicity = multiplicity,
+            molecular_multiplicity=multiplicity,
         )
 
     raise ValueError(f"Unknown molecule: {request.param}")
@@ -136,7 +138,9 @@ def get_atomic_input(
 
 
 @pytest.fixture()
-def atomic_input(molecule: "Molecule", driver: str, method: str, qcsk_version: int) -> "AtomicInput":
+def atomic_input(
+    molecule: "Molecule", driver: str, method: str, qcsk_version: int
+) -> "AtomicInput":
     """AtomicInput fixture."""
     return get_atomic_input(
         qcsk_version,
@@ -310,20 +314,24 @@ def test_qcschema(atomic_input: "AtomicInput", return_result: Any) -> None:
     assert pytest.approx(atomic_result.return_result) == return_result
 
 
-@pytest.fixture(params=[
-      {"cpcm-solvation": 7.0}, 
-      {"alpb-solvation": ["water", "bar1mol"]},
-      {"gbsa-solvation": ["methanol", "reference"]},
-      {"gbe-solvation": [7.0, "p16"]},
-      {"gb-solvation": [7.0, "still"]},
-   ])
+@pytest.fixture(
+    params=[
+        {"cpcm-solvation": 7.0},
+        {"alpb-solvation": ["water", "bar1mol"]},
+        {"gbsa-solvation": ["methanol", "reference"]},
+        {"gbe-solvation": [7.0, "p16"]},
+        {"gb-solvation": [7.0, "still"]},
+    ]
+)
 def solvation(request) -> dict:
     """Solvation fixture."""
     return request.param
 
 
 @pytest.fixture()
-def atomic_input_solvation(molecule: "Molecule", method: str, solvation: dict, qcsk_version: int) -> "AtomicInput":
+def atomic_input_solvation(
+    molecule: "Molecule", method: str, solvation: dict, qcsk_version: int
+) -> "AtomicInput":
     """AtomicInput fixture."""
     return get_atomic_input(
         qcsk_version,
@@ -398,7 +406,9 @@ def return_result_solvation(molecule: "Molecule", method: str, solvation: dict) 
 
 
 @pytest.mark.skipif(qcel_v1 is None and qcel_v2 is None, reason="requires qcelemental")
-def test_qcschema_solvation(atomic_input_solvation: "AtomicInput", return_result_solvation: Any) -> None:
+def test_qcschema_solvation(
+    atomic_input_solvation: "AtomicInput", return_result_solvation: Any
+) -> None:
     """Test qcschema interface."""
     atomic_result = run_schema(atomic_input_solvation)
 
@@ -461,8 +471,7 @@ def test_unsupported_basis(molecule: "Molecule", qcsk_version: int):
     assert not atomic_result.success
     assert atomic_result.error.error_type == "input_error"
     assert (
-        "Basis sets are not supported by tblite."
-        in atomic_result.error.error_message
+        "Basis sets are not supported by tblite." in atomic_result.error.error_message
     )
 
 

--- a/src/tblite/api/calculator.f90
+++ b/src/tblite/api/calculator.f90
@@ -31,7 +31,7 @@ module tblite_api_calculator
    use tblite_wavefunction, only : wavefunction_type, new_wavefunction, &
       & sad_guess, eeq_guess, eeqbc_guess, get_molecular_dipole_moment, &
       & get_molecular_quadrupole_moment
-   use tblite_xtb_calculator, only : xtb_calculator, new_xtb_calculator
+   use tblite_xtb_calculator, only : xtb_calculator, new_xtb_calculator, xtb_config
    use tblite_xtb_gfn2, only : new_gfn2_calculator
    use tblite_xtb_gfn1, only : new_gfn1_calculator
    use tblite_xtb_ipea1, only : new_ipea1_calculator
@@ -59,6 +59,11 @@ module tblite_api_calculator
    end enum
 
 
+   type, bind(c) :: xtb_config_struct
+      real(wp) :: smooth_cutoff
+   end type
+
+
    !> Void pointer to calculator type
    type :: vp_calculator
       !> Actual payload
@@ -82,7 +87,7 @@ module tblite_api_calculator
 contains
 
 
-function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
+function new_gfn2_calculator_api(vctx, vmol, config) result(vcalc) &
       & bind(C, name=namespace//"new_gfn2_calculator")
    type(c_ptr), value :: vctx
    type(vp_context), pointer :: ctx
@@ -90,6 +95,7 @@ function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(xtb_config_struct), intent(in), optional :: config
    type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_gfn2_calculator"
@@ -102,7 +108,7 @@ function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_gfn2_calculator(calc%ptr, mol%ptr, error)
+   call new_gfn2_calculator(calc%ptr, mol%ptr, error, convert_config(config))
    if (allocated(error)) then
       deallocate(calc)
       call ctx%ptr%set_error(error)
@@ -114,7 +120,7 @@ function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
 end function new_gfn2_calculator_api
 
 
-function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
+function new_ipea1_calculator_api(vctx, vmol, config) result(vcalc) &
       & bind(C, name=namespace//"new_ipea1_calculator")
    type(c_ptr), value :: vctx
    type(vp_context), pointer :: ctx
@@ -122,6 +128,7 @@ function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(xtb_config_struct), intent(in), optional :: config
    type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_ipea1_calculator"
@@ -134,7 +141,7 @@ function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_ipea1_calculator(calc%ptr, mol%ptr, error)
+   call new_ipea1_calculator(calc%ptr, mol%ptr, error, convert_config(config))
    if (allocated(error)) then
       deallocate(calc)
       call ctx%ptr%set_error(error)
@@ -146,7 +153,7 @@ function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
 end function new_ipea1_calculator_api
 
 
-function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
+function new_gfn1_calculator_api(vctx, vmol, config) result(vcalc) &
       & bind(C, name=namespace//"new_gfn1_calculator")
    type(c_ptr), value :: vctx
    type(vp_context), pointer :: ctx
@@ -154,6 +161,7 @@ function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(xtb_config_struct), intent(in), optional :: config
    type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_gfn1_calculator"
@@ -166,7 +174,7 @@ function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_gfn1_calculator(calc%ptr, mol%ptr, error)
+   call new_gfn1_calculator(calc%ptr, mol%ptr, error, convert_config(config))
    if (allocated(error)) then
       deallocate(calc)
       call ctx%ptr%set_error(error)
@@ -178,7 +186,7 @@ function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
 end function new_gfn1_calculator_api
 
 
-function new_xtb_calculator_api(vctx, vmol, vparam) result(vcalc) &
+function new_xtb_calculator_api(vctx, vmol, vparam, config) result(vcalc) &
       & bind(C, name=namespace//"new_xtb_calculator")
    type(c_ptr), value :: vctx
    type(vp_context), pointer :: ctx
@@ -188,6 +196,7 @@ function new_xtb_calculator_api(vctx, vmol, vparam) result(vcalc) &
    type(vp_param), pointer :: param
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(xtb_config_struct), intent(in), optional :: config
 
    type(error_type), allocatable :: error
 
@@ -204,7 +213,7 @@ function new_xtb_calculator_api(vctx, vmol, vparam) result(vcalc) &
    call c_f_pointer(vparam, param)
 
    allocate(calc)
-   call new_xtb_calculator(calc%ptr, mol%ptr, param%ptr, error)
+   call new_xtb_calculator(calc%ptr, mol%ptr, param%ptr, error, convert_config(config))
    if (allocated(error)) then
       deallocate(calc)
       call ctx%ptr%set_error(error)
@@ -702,5 +711,15 @@ call add_post_processing(calc%post_proc, mol%ptr, param%ptr%post_proc, error)
 if (allocated(error)) call ctx%ptr%set_error(error)
 
 end subroutine
+
+pure function convert_config(config) result(cfg)
+   type(xtb_config_struct), intent(in), optional :: config
+   type(xtb_config) :: cfg
+
+   cfg = xtb_config()
+   if (present(config)) then
+      cfg%smooth_cutoff = config%smooth_cutoff
+   end if
+end function convert_config
 
 end module tblite_api_calculator

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -149,6 +149,7 @@ subroutine update(self, mol, cache)
    type(coulomb_cache), pointer :: ptr
 
    call taint(cache, ptr)
+   call ptr%update(mol)
 
    if (.not.allocated(ptr%mrad)) then
       allocate(ptr%mrad(mol%nat))

--- a/src/tblite/xtb/calculator.f90
+++ b/src/tblite/xtb/calculator.f90
@@ -46,7 +46,7 @@ module tblite_xtb_calculator
    private
 
    public :: new_xtb_calculator
-   public :: param_h0spec
+   public :: param_h0spec, xtb_config
 
    !> Default value for self-consistent iteration mixing
    real(wp), parameter :: mixer_damping_default = 0.4_wp
@@ -118,11 +118,18 @@ module tblite_xtb_calculator
    end interface param_h0spec
 
 
+   !> Configuration for calculator
+   type :: xtb_config
+      !> Whether to use a smooth cutoff for the dispersion energy
+      real(wp) :: smooth_cutoff = 0.05_wp
+   end type xtb_config
+
+
 contains
 
 
 !> Create new xTB Hamiltonian calculator from parametrization data
-subroutine new_xtb_calculator(calc, mol, param, error)
+subroutine new_xtb_calculator(calc, mol, param, error, config)
    !> Instance of the xTB calculator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
@@ -131,9 +138,17 @@ subroutine new_xtb_calculator(calc, mol, param, error)
    type(param_record), intent(in) :: param
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Configuration for the calculator
+   type(xtb_config), intent(in), optional :: config
 
    integer :: isp
    integer, allocatable :: irc(:)
+   type(xtb_config) :: cfg
+
+   cfg = xtb_config()
+   if (present(config)) then
+      cfg = config
+   end if
 
    allocate(irc(mol%nid))
 
@@ -152,7 +167,7 @@ subroutine new_xtb_calculator(calc, mol, param, error)
    call add_hamiltonian(calc, mol, param, irc)
    call add_repulsion(calc, mol, param, irc)
    call add_halogen(calc, mol, param, irc)
-   call add_dispersion(calc, mol, param, error)
+   call add_dispersion(calc, mol, param, error, cfg%smooth_cutoff)
    if (allocated(error)) return
    call add_coulomb(calc, mol, param, irc, error)
    if (allocated(error)) return
@@ -240,7 +255,7 @@ subroutine add_hamiltonian(calc, mol, param, irc)
 end subroutine add_hamiltonian
 
 
-subroutine add_dispersion(calc, mol, param, error)
+subroutine add_dispersion(calc, mol, param, error, smooth_cutoff)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(inout) :: calc
    !> Molecular structure data
@@ -249,6 +264,8 @@ subroutine add_dispersion(calc, mol, param, error)
    type(param_record), intent(in) :: param
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Whether to use a smooth cutoff for the dispersion energy
+   real(wp), intent(in) :: smooth_cutoff
 
    type(d4_dispersion), allocatable :: d4
    type(d3_dispersion), allocatable :: d3
@@ -258,16 +275,19 @@ subroutine add_dispersion(calc, mol, param, error)
       if (par%d3) then
          allocate(d3)
          call new_d3_dispersion(d3, mol, s6=par%s6, s8=par%s8, &
-            & a1=par%a1, a2=par%a2, s9=par%s9, error=error)
+            & a1=par%a1, a2=par%a2, s9=par%s9, error=error, &
+            & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
          call move_alloc(d3, calc%dispersion)
       else
          allocate(d4)
          if (par%smooth) then 
             call new_d4s_dispersion(d4, mol, s6=par%s6, s8=par%s8, &
-               & a1=par%a1, a2=par%a2, s9=par%s9, error=error)
+               & a1=par%a1, a2=par%a2, s9=par%s9, error=error, &
+               & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
          else
             call new_d4_dispersion(d4, mol, s6=par%s6, s8=par%s8, &
-               & a1=par%a1, a2=par%a2, s9=par%s9, error=error)
+               & a1=par%a1, a2=par%a2, s9=par%s9, error=error, &
+               & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
          end if
          call move_alloc(d4, calc%dispersion)
       end if

--- a/src/tblite/xtb/gfn1.f90
+++ b/src/tblite/xtb/gfn1.f90
@@ -34,7 +34,7 @@ module tblite_xtb_gfn1
    use tblite_disp, only : d3_dispersion, new_d3_dispersion
    use tblite_param, only : param_record
    use tblite_repulsion, only : new_repulsion
-   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtb_calculator, only : xtb_calculator, xtb_config
    use tblite_xtb_h0, only : new_hamiltonian
    use tblite_xtb_spec, only : tb_h0spec
    use tblite_output_format, only : format_string
@@ -516,13 +516,22 @@ module tblite_xtb_gfn1
 contains
 
 
-subroutine new_gfn1_calculator(calc, mol, error)
+subroutine new_gfn1_calculator(calc, mol, error, config)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Configuration options for the calculator
+   type(xtb_config), intent(in), optional :: config
+
+   type(xtb_config) :: cfg
+
+   cfg = xtb_config()
+   if (present(config)) then
+      cfg = config
+   end if
 
    ! Check if all atoms of mol%nat are supported (Z <= 86)
    if (any(mol%num > max_elem)) then
@@ -535,7 +544,7 @@ subroutine new_gfn1_calculator(calc, mol, error)
    if (allocated(error)) return
    call add_hamiltonian(calc, mol)
    call add_repulsion(calc, mol)
-   call add_dispersion(calc, mol, error)
+   call add_dispersion(calc, mol, error, smooth_cutoff=cfg%smooth_cutoff)
    if (allocated(error)) return
    call add_coulomb(calc, mol)
    call add_halogen(calc, mol)
@@ -593,18 +602,21 @@ subroutine add_hamiltonian(calc, mol)
    call new_hamiltonian(calc%h0, mol, calc%bas, new_gfn1_h0spec(mol))
 end subroutine add_hamiltonian
 
-subroutine add_dispersion(calc, mol, error)
+subroutine add_dispersion(calc, mol, error, smooth_cutoff)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(inout) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Whether to use a smooth cutoff for the dispersion energy
+   real(wp), intent(in) :: smooth_cutoff
 
    type(d3_dispersion), allocatable :: tmp
 
    allocate(tmp)
-   call new_d3_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error)
+   call new_d3_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error, &
+      & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
    call move_alloc(tmp, calc%dispersion)
 end subroutine add_dispersion
 

--- a/src/tblite/xtb/gfn2.f90
+++ b/src/tblite/xtb/gfn2.f90
@@ -33,7 +33,7 @@ module tblite_xtb_gfn2
    use tblite_disp, only : d4_dispersion, new_d4_dispersion
    use tblite_param, only : param_record
    use tblite_repulsion, only : new_repulsion
-   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtb_calculator, only : xtb_calculator, xtb_config
    use tblite_xtb_h0, only : new_hamiltonian
    use tblite_xtb_spec, only : tb_h0spec
    use tblite_output_format, only : format_string
@@ -567,13 +567,22 @@ module tblite_xtb_gfn2
 contains
 
 
-subroutine new_gfn2_calculator(calc, mol, error)
+subroutine new_gfn2_calculator(calc, mol, error, config)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Configuration options for the calculator
+   type(xtb_config), intent(in), optional :: config
+
+   type(xtb_config) :: cfg
+
+   cfg = xtb_config()
+   if (present(config)) then
+      cfg = config
+   end if
 
    ! Check if all atoms of mol%nat are supported (Z <= 86)
    if (any(mol%num > max_elem)) then
@@ -586,7 +595,7 @@ subroutine new_gfn2_calculator(calc, mol, error)
    if (allocated(error)) return
    call add_hamiltonian(calc, mol)
    call add_repulsion(calc, mol)
-   call add_dispersion(calc, mol, error)
+   call add_dispersion(calc, mol, error, cfg%smooth_cutoff)
    if (allocated(error)) return
    call add_coulomb(calc, mol, error)
    if (allocated(error)) return
@@ -640,18 +649,21 @@ subroutine add_hamiltonian(calc, mol)
    call new_hamiltonian(calc%h0, mol, calc%bas, new_gfn2_h0spec(mol))
 end subroutine add_hamiltonian
 
-subroutine add_dispersion(calc, mol, error)
+subroutine add_dispersion(calc, mol, error, smooth_cutoff)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(inout) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Whether to use a smooth cutoff for the dispersion energy
+   real(wp), intent(in) :: smooth_cutoff
 
    type(d4_dispersion), allocatable :: tmp
 
    allocate(tmp)
-   call new_d4_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error)
+   call new_d4_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error, &
+      & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
    call move_alloc(tmp, calc%dispersion)
 end subroutine add_dispersion
 

--- a/src/tblite/xtb/ipea1.f90
+++ b/src/tblite/xtb/ipea1.f90
@@ -34,7 +34,7 @@ module tblite_xtb_ipea1
    use tblite_disp, only : d3_dispersion, new_d3_dispersion
    use tblite_param, only : param_record
    use tblite_repulsion, only : new_repulsion
-   use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_xtb_calculator, only : xtb_calculator, xtb_config
    use tblite_xtb_h0, only : new_hamiltonian
    use tblite_xtb_spec, only : tb_h0spec
    use tblite_output_format, only : format_string
@@ -526,13 +526,22 @@ module tblite_xtb_ipea1
 contains
 
 
-subroutine new_ipea1_calculator(calc, mol, error)
+subroutine new_ipea1_calculator(calc, mol, error, config)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Configuration options for the calculator
+   type(xtb_config), intent(in), optional :: config
+
+   type(xtb_config) :: cfg
+
+   cfg = xtb_config()
+   if (present(config)) then
+      cfg = config
+   end if
 
    ! Check if all atoms of mol%nat are supported (Z <= 86)
    if (any(mol%num > max_elem)) then
@@ -545,7 +554,7 @@ subroutine new_ipea1_calculator(calc, mol, error)
    if (allocated(error)) return
    call add_hamiltonian(calc, mol)
    call add_repulsion(calc, mol)
-   call add_dispersion(calc, mol, error)
+   call add_dispersion(calc, mol, error, cfg%smooth_cutoff)
    if (allocated(error)) return
    call add_coulomb(calc, mol)
    call add_halogen(calc, mol)
@@ -603,18 +612,21 @@ subroutine add_hamiltonian(calc, mol)
    call new_hamiltonian(calc%h0, mol, calc%bas, new_ipea1_h0spec(mol))
 end subroutine add_hamiltonian
 
-subroutine add_dispersion(calc, mol, error)
+subroutine add_dispersion(calc, mol, error, smooth_cutoff)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(inout) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
+   !> Whether to use a smooth cutoff for the dispersion energy
+   real(wp), intent(in) :: smooth_cutoff
 
    type(d3_dispersion), allocatable :: tmp
 
    allocate(tmp)
-   call new_d3_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error)
+   call new_d3_dispersion(tmp, mol, s6=s6, s8=s8, a1=a1, a2=a2, s9=s9, error=error, &
+      & disp2_width=smooth_cutoff, disp3_width=smooth_cutoff)
    call move_alloc(tmp, calc%dispersion)
 end subroutine add_dispersion
 

--- a/test/api/main.c
+++ b/test/api/main.c
@@ -1162,7 +1162,7 @@ int test_calc_restart(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -1184,7 +1184,7 @@ int test_calc_restart(void)
 
     // reset calculator
     tblite_delete(calc);
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
 
     tblite_get_singlepoint(ctx, mol, calc, res1);
     if (tblite_check(ctx))
@@ -1278,7 +1278,7 @@ int test_callback(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
 
     tblite_get_singlepoint(ctx, mol, calc, res);
     if (tblite_check(ctx))
@@ -1395,7 +1395,7 @@ int test_gfn2_si5h12(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_xtb_calculator(ctx, mol, param);
+    calc = tblite_new_xtb_calculator(ctx, mol, param, NULL);
     if (!calc)
         goto err;
 
@@ -1600,7 +1600,7 @@ int test_ipea1_ch4(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_ipea1_calculator(ctx, mol);
+    calc = tblite_new_ipea1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -1724,7 +1724,8 @@ int test_gfn1_co2(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    tblite_xtb_config cfg = { 0.0 };
+    calc = tblite_new_gfn1_calculator(ctx, mol, &cfg);
     if (!calc)
         goto err;
 
@@ -1829,7 +1830,7 @@ int test_gfn2_convergence(void)
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_xtb_calculator(ctx, mol, param);
+    calc = tblite_new_xtb_calculator(ctx, mol, param, NULL);
     if (!calc)
         goto err;
 
@@ -1900,7 +1901,7 @@ int test_spgfn1()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -2031,7 +2032,7 @@ int test_dict_api()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -2337,7 +2338,7 @@ int test_uninitialized_dict()
     if (tblite_check(error))
         goto unexpected;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto unexpected;
 
@@ -2490,7 +2491,7 @@ int test_h2plus_wbo()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (tblite_check(ctx))
         goto err;
 
@@ -2570,7 +2571,7 @@ int test_h2plus_wbo()
 
     calc = NULL;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (tblite_check(ctx))
         goto err;
 
@@ -2674,7 +2675,7 @@ int test_post_processing_api()
 
     show(ctx);
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -2877,7 +2878,7 @@ int test_post_processing_api()
         goto err;
     show(ctx);
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -2911,7 +2912,7 @@ int test_post_processing_api()
     if (!check_int(n_dict_entries, 1, "Check number of entries in dict, using param for push_back")) {
         goto err;
     }
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     cont = tblite_new_spin_polarization(ctx, mol, calc, 1.0);
     if (tblite_check(ctx))
         goto err;
@@ -3007,7 +3008,7 @@ int test_xtbml_api()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3063,7 +3064,7 @@ int test_xtbml_api()
     tblite_delete(calc);
     tblite_delete(dict);
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3181,7 +3182,7 @@ int test_solvation_cpcm_eps()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3253,7 +3254,7 @@ int test_solvation_alpb_eps()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3325,7 +3326,7 @@ int test_solvation_alpb_gfn2()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3397,7 +3398,7 @@ int test_solvation_gbsa_gfn2()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3469,7 +3470,7 @@ int test_solvation_gb_eps()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn2_calculator(ctx, mol);
+    calc = tblite_new_gfn2_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3541,7 +3542,7 @@ int test_solvation_alpb_gfn1()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 
@@ -3613,7 +3614,7 @@ int test_solvation_gbsa_gfn1()
     if (tblite_check(error))
         goto err;
 
-    calc = tblite_new_gfn1_calculator(ctx, mol);
+    calc = tblite_new_gfn1_calculator(ctx, mol, NULL);
     if (!calc)
         goto err;
 

--- a/test/cli/06a-gfn1xtb.resp
+++ b/test/cli/06a-gfn1xtb.resp
@@ -4,3 +4,5 @@ $ORIGIN/06-ammonia.tmol
 --method
 gfn1
 --grad
+--config
+smooth_cutoff=0

--- a/test/cli/tester.py
+++ b/test/cli/tester.py
@@ -8,7 +8,10 @@ supposed to be used by meson for testing purposes only.
 """
 
 try:
-    import subprocess, sys, json, os
+    import json
+    import os
+    import subprocess
+    import sys
 except ImportError:
     exit(77)
 


### PR DESCRIPTION
For allowing smooth cutoff configuration as implemented in CP2K for xTB via tblite. Defaults to smooth cutoff of 0.05 as used in CP2K.

- [x] expose smooth cutoff config in Fortran API
- [x] expose smooth cutoff config in C API
- [x] expose smooth cutoff config in Python API