### PR TITLE
Expose MORFEUS-oriented descriptors via Python Result API

### DIFF
--- a/include/tblite/result.h
+++ b/include/tblite/result.h
@@ -235,6 +235,26 @@ tblite_get_result_hamiltonian_matrix(tblite_error error,
                                      tblite_result res,
                                      double* hmat);
 
+/// Retrieve covalent coordination numbers from result container
+///
+/// @param error: Handle for error messages
+/// @param res: Result container
+/// @param covcn: Covalent coordination numbers, shape [nat]
+TBLITE_API_ENTRY void TBLITE_API_CALL
+tblite_get_result_covcn(tblite_error error,
+                        tblite_result res,
+                        double* covcn);
+
+/// Retrieve CM5 charges from result container
+///
+/// @param error: Handle for error messages
+/// @param res: Result container
+/// @param cm5: CM5 charges, shape [nat]
+TBLITE_API_ENTRY void TBLITE_API_CALL
+tblite_get_result_cm5_charges(tblite_error error,
+                              tblite_result res,
+                              double* cm5);
+
 /// Retrieve Hamiltonian matrix from result container
 ///
 /// @param error: Handle for error messages

--- a/python/tblite/interface.py
+++ b/python/tblite/interface.py
@@ -85,9 +85,7 @@ class Structure:
             raise TBLiteValueError("Expected tripels of cartesian coordinates")
 
         if 3 * numbers.size != positions.size:
-            raise TBLiteValueError(
-                "Dimension missmatch between numbers and positions"
-            )
+            raise TBLiteValueError("Dimension missmatch between numbers and positions")
 
         self._natoms = len(numbers)
         _numbers = np.ascontiguousarray(numbers, dtype="i4")
@@ -245,6 +243,16 @@ class Result:
         "density-matrix": library.get_density_matrix,
         "overlap-matrix": library.get_overlap_matrix,
         "hamiltonian-matrix": library.get_hamiltonian_matrix,
+        "covcn": library.get_covcn,
+        "cm5-charges": library.get_cm5_charges,
+        "fractional-occupation-density": library.get_fractional_occupation_density,
+        "fukui-plus": library.get_fukui_plus,
+        "fukui-minus": library.get_fukui_minus,
+        "fukui-radical": library.get_fukui_radical,
+        "fukui-dual": library.get_fukui_dual,
+        "ip-correction": library.get_ip_correction,
+        "ea-correction": library.get_ea_correction,
+        "fod": library.get_fod,
         "post-processing-dict": library.get_post_processing_dict,
         "natoms": library.get_number_of_atoms,
         "norbitals": library.get_number_of_orbitals,
@@ -283,6 +291,16 @@ class Result:
          overlap-matrix         norb, norb                        unitless
          hamiltonian-matrix     norb, norb                        Hartree
          density-matrix         norb, norb [2, norb, norb]        e
+         covcn                  nat                               unitless
+         cm5-charges            nat                               e
+         fractional-occupation-density norb                       e
+         fukui-plus             nat                               e
+         fukui-minus            nat                               e
+         fukui-radical          nat                               e
+         fukui-dual             nat                               e
+         ip-correction          scalar                            eV
+         ea-correction          scalar                            eV
+         fod                    nat                               e
          natoms                 scalar                            unitless
          norbitals              scalar                            unitless
          post-processing-dict   dependes on the key               /
@@ -344,7 +362,7 @@ class Result:
             if the saving fails
         """
         library.save_wavefunction(self._res, filename)
-    
+
     def load(self, filename: str) -> None:
         """
         Load a result container from a file. The format is compatible with the
@@ -499,10 +517,10 @@ class Calculator(Structure):
         "gb-solvation": library.new_gb_solvation,
     }
     _post_processing = {
-        "bond-orders" : "bond-orders",
-        "molecular-multipoles" : "molmom",
-        "xtbml" : "xtbml",
-        "xtbml_xyz" : "xtbml_xyz"
+        "bond-orders": "bond-orders",
+        "molecular-multipoles": "molmom",
+        "xtbml": "xtbml",
+        "xtbml_xyz": "xtbml_xyz",
     }
 
     def __init__(
@@ -524,9 +542,7 @@ class Calculator(Structure):
         TBLiteValueError
             on invalid input, like incorrect shape / type of the passed arrays
         """
-        Structure.__init__(
-            self, numbers, positions, charge, uhf, lattice, periodic
-        )
+        Structure.__init__(self, numbers, positions, charge, uhf, lattice, periodic)
 
         self._ctx = library.new_context(**context_kwargs)
         if method not in self._loader:
@@ -642,11 +658,8 @@ class Calculator(Structure):
                 f"Attribute '{attribute}' is not supported in this calculator"
             )
         return self._getter[attribute](self._ctx, self._calc)
-        
 
-    def singlepoint(
-        self, res: Optional[Result] = None, copy: bool = False
-    ) -> Result:
+    def singlepoint(self, res: Optional[Result] = None, copy: bool = False) -> Result:
         """
         Perform actual single point calculation in the library backend.
         The output of the library will be forwarded to the standard output.
@@ -706,9 +719,7 @@ ELEMENT_SYMBOLS = [
 ]
 # fmt: on
 
-SYMBOL_TO_NUMBER = {
-    symbol: number + 1 for number, symbol in enumerate(ELEMENT_SYMBOLS)
-}
+SYMBOL_TO_NUMBER = {symbol: number + 1 for number, symbol in enumerate(ELEMENT_SYMBOLS)}
 
 
 def symbols_to_numbers(symbols: List[str]) -> List[int]:

--- a/python/tblite/library.py
+++ b/python/tblite/library.py
@@ -29,9 +29,7 @@ import numpy as np
 try:
     from ._libtblite import ffi, lib
 except ImportError as e:
-    raise ImportError(
-        "tblite C extension unimportable, cannot use C-API"
-    ) from e
+    raise ImportError("tblite C extension unimportable, cannot use C-API") from e
 
 from .exceptions import TBLiteRuntimeError, TBLiteValueError
 
@@ -125,9 +123,7 @@ def new_context(color: bool = True, logger: Callable[[str], None] = print):
     """Create new tblite context handler object"""
     ctx = ffi.gc(lib.tblite_new_context(), _delete_context)
     handle = ffi.new_handle(logger)
-    context_check(lib.tblite_set_context_logger)(
-        ctx, lib.logger_callback, handle
-    )
+    context_check(lib.tblite_set_context_logger)(ctx, lib.logger_callback, handle)
     if color and sys.stdout.isatty():
         context_check(lib.tblite_set_context_color)(ctx, 1)
     return ctx, handle
@@ -381,9 +377,7 @@ get_orbital_coefficients = _get_ao_matrix(
 )
 get_density_matrix = _get_ao_matrix(lib.tblite_get_result_density_matrix, True)
 get_overlap_matrix = _get_ao_matrix(lib.tblite_get_result_overlap_matrix, False)
-get_hamiltonian_matrix = _get_ao_matrix(
-    lib.tblite_get_result_hamiltonian_matrix, False
-)
+get_hamiltonian_matrix = _get_ao_matrix(lib.tblite_get_result_hamiltonian_matrix, False)
 
 
 def _delete_calculator(calc) -> None:
@@ -414,9 +408,7 @@ def new_ipea1_calculator(ctx, mol):
 @context_check
 def new_xtb_calculator(ctx, mol, param):
     """Create new tblite calculator from parametrization records"""
-    return ffi.gc(
-        lib.tblite_new_xtb_calculator(ctx, mol, param), _delete_calculator
-    )
+    return ffi.gc(lib.tblite_new_xtb_calculator(ctx, mol, param), _delete_calculator)
 
 
 def get_calculator_shell_map(ctx, calc) -> np.ndarray:
@@ -451,9 +443,7 @@ def get_post_processing_dict(res) -> Dict[str, np.ndarray]:
         _dim1 = ffi.new("int*")
         _dim2 = ffi.new("int*")
         _dim3 = ffi.new("int*")
-        error_check(lib.tblite_get_array_size_index)(
-            _dict, _index, _dim1, _dim2, _dim3
-        )
+        error_check(lib.tblite_get_array_size_index)(_dict, _index, _dim1, _dim2, _dim3)
         if _dim3[0] == 0:
             if _dim2[0] == 0:
                 _array = np.zeros((_dim1[0],))
@@ -466,12 +456,107 @@ def get_post_processing_dict(res) -> Dict[str, np.ndarray]:
             _dict, _index, ffi.cast("double*", _array.ctypes.data)
         )
         _message = ffi.new("char[]", 512)
-        error_check(lib.tblite_get_label_entry_index)(
-            _dict, _index, _message, ffi.NULL
-        )
+        error_check(lib.tblite_get_label_entry_index)(_dict, _index, _message, ffi.NULL)
         label = ffi.string(_message).decode()
         _dict_py[label] = _array
     return _dict_py
+
+
+def _get_post_processing_entry(res, label: str, message: str) -> np.ndarray:
+    """Retrieve one entry from the post-processing dictionary."""
+    data = get_post_processing_dict(res=res)
+    if label not in data:
+        raise TBLiteValueError(message)
+    return data[label]
+
+
+def get_covcn(res) -> np.ndarray:
+    """Retrieve covalent coordination numbers from result container."""
+    _covcn = np.zeros((get_number_of_atoms(res),))
+    error_check(lib.tblite_get_result_covcn)(
+        res, ffi.cast("double*", _covcn.ctypes.data)
+    )
+    return _covcn
+
+
+def get_cm5_charges(res) -> np.ndarray:
+    """Retrieve CM5 charges from result container."""
+    _cm5 = np.zeros((get_number_of_atoms(res),))
+    error_check(lib.tblite_get_result_cm5_charges)(
+        res, ffi.cast("double*", _cm5.ctypes.data)
+    )
+    return _cm5
+
+
+def get_fractional_occupation_density(res) -> np.ndarray:
+    """Retrieve fractional occupation density proxy from orbital occupations."""
+    occ = get_orbital_occupations(res)
+    if occ.ndim == 1:
+        return occ * (2.0 - occ)
+    return np.sum(occ * (1.0 - occ), axis=0)
+
+
+def get_fukui_plus(res) -> np.ndarray:
+    """Retrieve electrophilic Fukui function."""
+    return _get_post_processing_entry(
+        res,
+        "fukui-plus",
+        "Fukui functions were not calculated for this result.",
+    )
+
+
+def get_fukui_minus(res) -> np.ndarray:
+    """Retrieve nucleophilic Fukui function."""
+    return _get_post_processing_entry(
+        res,
+        "fukui-minus",
+        "Fukui functions were not calculated for this result.",
+    )
+
+
+def get_fukui_radical(res) -> np.ndarray:
+    """Retrieve radical Fukui function."""
+    return _get_post_processing_entry(
+        res,
+        "fukui-radical",
+        "Fukui functions were not calculated for this result.",
+    )
+
+
+def get_fukui_dual(res) -> np.ndarray:
+    """Retrieve dual descriptor from Fukui functions."""
+    return _get_post_processing_entry(
+        res,
+        "fukui-dual",
+        "Fukui functions were not calculated for this result.",
+    )
+
+
+def get_ip_correction(res) -> np.ndarray:
+    """Retrieve IP correction term."""
+    return _get_post_processing_entry(
+        res,
+        "ip-correction",
+        "IP correction is not available in this result.",
+    )
+
+
+def get_ea_correction(res) -> np.ndarray:
+    """Retrieve EA correction term."""
+    return _get_post_processing_entry(
+        res,
+        "ea-correction",
+        "EA correction is not available in this result.",
+    )
+
+
+def get_fod(res) -> np.ndarray:
+    """Retrieve fractional occupation density (FOD)."""
+    return _get_post_processing_entry(
+        res,
+        "fod",
+        "Fractional occupation density is not available in this result.",
+    )
 
 
 def get_calculator_angular_momenta(ctx, calc) -> np.ndarray:
@@ -498,16 +583,10 @@ def get_calculator_orbital_map(ctx, calc) -> np.ndarray:
 
 set_calculator_max_iter = context_check(lib.tblite_set_calculator_max_iter)
 set_calculator_accuracy = context_check(lib.tblite_set_calculator_accuracy)
-set_calculator_mixer_damping = context_check(
-    lib.tblite_set_calculator_mixer_damping
-)
+set_calculator_mixer_damping = context_check(lib.tblite_set_calculator_mixer_damping)
 set_calculator_guess = context_check(lib.tblite_set_calculator_guess)
-set_calculator_temperature = context_check(
-    lib.tblite_set_calculator_temperature
-)
-set_calculator_save_integrals = context_check(
-    lib.tblite_set_calculator_save_integrals
-)
+set_calculator_temperature = context_check(lib.tblite_set_calculator_temperature)
+set_calculator_save_integrals = context_check(lib.tblite_set_calculator_save_integrals)
 
 
 @context_check
@@ -587,9 +666,7 @@ def new_gb_solvation(ctx, mol, calc, epsilon: float, born: str):
 
 def new_cpcm_solvation(ctx, mol, calc, epsilon: float):
     """Create new tblite CPCM solvation object"""
-    return error_check(lib.tblite_new_cpcm_solvation_epsilon)(
-        mol, float(epsilon)
-    )
+    return error_check(lib.tblite_new_cpcm_solvation_epsilon)(mol, float(epsilon))
 
 
 @context_check

--- a/python/tblite/test_interface.py
+++ b/python/tblite/test_interface.py
@@ -118,9 +118,7 @@ def get_ala(conf):
 
 def get_crcp2():
     """Get structure for CrCP2"""
-    numbers = np.array(
-        [24, 6, 6, 6, 6, 6, 1, 1, 1, 1, 1, 6, 6, 6, 1, 6, 1, 6, 1, 1, 1]
-    )
+    numbers = np.array([24, 6, 6, 6, 6, 6, 1, 1, 1, 1, 1, 6, 6, 6, 1, 6, 1, 6, 1, 1, 1])
     positions = np.array(
         [
             [+0.00000000000000, +0.00000000000000, -0.06044684528305],
@@ -519,6 +517,7 @@ def test_post_processing_api():
     wbo_sp = calc.singlepoint().get("bond-orders")
     assert wbo_sp.ndim == 3
 
+
 def test_xtbml_api():
     numbers, positions = get_crcp2()
     calc = Calculator("GFN1-xTB", numbers, positions)
@@ -532,29 +531,60 @@ def test_xtbml_api():
     dict_xtbml = res.dict()
     dict_xtbml = dict_xtbml.get("post-processing-dict")
     assert len(dict_xtbml.keys()) == 39
-    
-    toml_inp = ["[post-processing.xtbml] \n",
-                "geometry = false \n",
-                "density = true \n",
-                "orbital = true \n",
-                "energy = false \n", 
-                "convolution = true\n",
-                "a = [1.0, 1.2]\n",
-                "tensorial-output = true"]
-    
+
+    toml_inp = [
+        "[post-processing.xtbml] \n",
+        "geometry = false \n",
+        "density = true \n",
+        "orbital = true \n",
+        "energy = false \n",
+        "convolution = true\n",
+        "a = [1.0, 1.2]\n",
+        "tensorial-output = true",
+    ]
+
     with open("xtbml.toml", "w") as f:
         f.writelines(toml_inp)
-        
+
     calc = Calculator("GFN1-xTB", numbers, positions)
     calc.add("xtbml.toml")
-    
+
     res = calc.singlepoint()
     dict_ = res.get("post-processing-dict")
-    
+
     assert dict_.get("CN_A") is None
 
     assert len(dict_.keys()) == 130
-    
+
+
+def test_descriptor_aliases_and_missing_properties():
+    numbers, positions = get_crcp2()
+    calc = Calculator("GFN1-xTB", numbers, positions)
+    calc.add("xtbml")
+    res = calc.singlepoint()
+
+    covcn = res.get("covcn")
+    assert covcn.shape == (numbers.size,)
+    assert covcn == approx(res.get("post-processing-dict")["CN_A"], abs=THR)
+
+    fod = res.get("fractional-occupation-density")
+    assert fod.shape == (res.get("norbitals"),)
+    assert np.all(fod >= 0.0)
+
+    unavailable_properties = [
+        "cm5-charges",
+        "fukui-plus",
+        "fukui-minus",
+        "fukui-radical",
+        "fukui-dual",
+        "ip-correction",
+        "ea-correction",
+        "fod",
+    ]
+    for prop in unavailable_properties:
+        with raises((TBLiteValueError, TBLiteRuntimeError)):
+            res.get(prop)
+
 
 def test_solvation_gfn2_cpcm():
     """Test CPCM solvation with GFN2-xTB"""
@@ -637,7 +667,8 @@ def test_solvation_gfn2_gb():
     calc.add("gb-solvation", 7.0, "still")
 
     energy = calc.singlepoint().get("energy")
-    assert energy == approx(-28.43676829542, abs=THR) 
+    assert energy == approx(-28.43676829542, abs=THR)
+
 
 def test_solvation_gfn1_alpb():
     """Test ALPB solvation with GFN1-xTB"""
@@ -667,7 +698,6 @@ def test_result_getter():
 
     with raises(ValueError, match="Attribute 'unknown' is not available"):
         res.get("unknown")
-    
 
 
 def test_result_setter():
@@ -706,9 +736,7 @@ def test_gfn1_logging():
 
     logger = Logger("test")
 
-    calc = Calculator(
-        "GFN1-xTB", numbers, positions, color=False, logger=logger.info
-    )
+    calc = Calculator("GFN1-xTB", numbers, positions, color=False, logger=logger.info)
     res = calc.singlepoint()
 
     assert res.get("energy") == approx(-34.980794815805446, abs=THR)
@@ -716,9 +744,7 @@ def test_gfn1_logging():
     def broken_logger(message: str) -> None:
         raise NotImplementedError("This logger is broken")
 
-    calc = Calculator(
-        "GFN1-xTB", numbers, positions, color=False, logger=broken_logger
-    )
+    calc = Calculator("GFN1-xTB", numbers, positions, color=False, logger=broken_logger)
     with raises(TBLiteRuntimeError):
         calc.singlepoint()
 
@@ -764,13 +790,17 @@ def test_numbers():
 def test_spin_polarized_restart():
     # Use a small open-shell system (e.g., NO) in Bohr
     numbers = np.array([7, 8], dtype=np.int32)
-    positions = np.array([
-        [0.0, 0.0, -1.1],
-        [0.0, 0.0,  1.1],
-    ], dtype=float)
+    positions = np.array(
+        [
+            [0.0, 0.0, -1.1],
+            [0.0, 0.0, 1.1],
+        ],
+        dtype=float,
+    )
 
     # Capture output to count iterations
     log = []
+
     def logger(msg):
         log.append(msg)
 
@@ -778,11 +808,11 @@ def test_spin_polarized_restart():
     calc = Calculator("GFN2-xTB", numbers, positions, uhf=1, logger=logger)
     calc.add("spin-polarization", 1.0)
     calc.set("verbosity", 1)
-    
+
     # Full run
     res_full = calc.singlepoint()
     energy_full = res_full.get("energy")
-    
+
     # Clear log for restart run
     log.clear()
 
@@ -790,17 +820,17 @@ def test_spin_polarized_restart():
     res_restart_wfn = Result(res_full)
     res_restart_wfn = calc.singlepoint(res_restart_wfn)
     energy_restart_wfn = res_restart_wfn.get("energy")
-    
+
     # Count iterations (lines starting with an integer index)
     iterations = 0
     for line in log:
         parts = line.strip().split()
         if len(parts) > 0 and parts[0].isdigit():
             iterations += 1
-            
+
     # Check energy consistency
     assert abs(energy_full - energy_restart_wfn) < 1e-8
-    
+
     # Verify iteration count (should be very low, e.g., <= 3)
     # Ideally 1 or 2 if restart is perfect
     assert iterations <= 3, f"Restart took {iterations} iterations, expected <= 3"

--- a/src/tblite/api/result.f90
+++ b/src/tblite/api/result.f90
@@ -40,6 +40,7 @@ module tblite_api_result
       & get_result_orbital_coefficients_api, get_result_energies_api, &
       & get_result_density_matrix_api, get_result_overlap_matrix_api, &
       & get_result_hamiltonian_matrix_api, get_result_bond_orders_api, &
+      & get_result_covcn_api, get_result_cm5_charges_api, &
       & get_post_processing_dict_api
 
 
@@ -568,6 +569,68 @@ subroutine get_result_bond_orders_api(verror, vres, mbo) &
    mbo(:size(mbo_f)) = &
       & reshape(mbo_f, [size(mbo_f)])
 end subroutine get_result_bond_orders_api
+
+
+subroutine get_result_covcn_api(verror, vres, covcn) &
+      & bind(C, name=namespace//"get_result_covcn")
+   type(c_ptr), value :: verror
+   type(vp_error), pointer :: error
+   type(c_ptr), value :: vres
+   type(vp_result), pointer :: res
+   real(c_double), intent(out) :: covcn(*)
+   real(kind=wp), allocatable :: covcn_f(:)
+   logical :: ok
+
+   if (debug) print '("[Info]", 1x, a)', "get_result_covcn"
+
+   call get_result(verror, vres, error, res, ok)
+   if (.not.ok) return
+
+   if (.not.allocated(res%results)) then
+      call fatal_error(error%ptr, "Result does not contain covalent coordination numbers")
+      return
+   end if
+
+   call res%results%dict%get_entry("CN_A", covcn_f)
+
+   if (.not.allocated(covcn_f)) then
+      call fatal_error(error%ptr, "Could not find covalent coordination numbers in results dictionary")
+      return
+   end if
+
+   covcn(:size(covcn_f)) = covcn_f
+end subroutine get_result_covcn_api
+
+
+subroutine get_result_cm5_charges_api(verror, vres, cm5) &
+      & bind(C, name=namespace//"get_result_cm5_charges")
+   type(c_ptr), value :: verror
+   type(vp_error), pointer :: error
+   type(c_ptr), value :: vres
+   type(vp_result), pointer :: res
+   real(c_double), intent(out) :: cm5(*)
+   real(kind=wp), allocatable :: cm5_f(:)
+   logical :: ok
+
+   if (debug) print '("[Info]", 1x, a)', "get_result_cm5_charges"
+
+   call get_result(verror, vres, error, res, ok)
+   if (.not.ok) return
+
+   if (.not.allocated(res%results)) then
+      call fatal_error(error%ptr, "Result does not contain CM5 charges")
+      return
+   end if
+
+   call res%results%dict%get_entry("cm5-charges", cm5_f)
+
+   if (.not.allocated(cm5_f)) then
+      call fatal_error(error%ptr, "Could not find CM5 charges in results dictionary")
+      return
+   end if
+
+   cm5(:size(cm5_f)) = cm5_f
+end subroutine get_result_cm5_charges_api
 
 function get_post_processing_dict_api(verror, vres) result(vdict) &
    & bind(C, name=namespace//"get_post_processing_dict")


### PR DESCRIPTION
Add stable Result.get keys for covCN (CN_A), CM5 when stored in the result dictionary, a fractional-occupation-density proxy from MO occupations, and explicit accessors for Fukui / IP-EA / FOD that raise clear errors until those entries are populated. Extend the C API with tblite_get_result_covcn and tblite_get_result_cm5_charges backed by the Fortran result layer. Code may not be perfect and some other properties could and should be exposed too!

This lets MORFEUS and similar consumers rely on top-level keys instead of only post-processing-dict labels, while keeping existing keys unchanged. Ultimately, this is meant to reduce the near-infinite number of codebases that parse XTB output files and help migrate XTB-based workflows to tblite eventually. 