### PR TITLE
Fix multipole ewald + virials with updated scaling tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
          --no-rebuild
          --num-processes 1
          --suite tblite
-         -t 2
+         -t 10
       env:
         OMP_NUM_THREADS: 1,2,1
 

--- a/src/tblite/coulomb/cache.f90
+++ b/src/tblite/coulomb/cache.f90
@@ -31,6 +31,7 @@ module tblite_coulomb_cache
 
    type :: coulomb_cache
       real(wp) :: alpha
+      real(wp) :: alpha_multipole
       type(wignerseitz_cell) :: wsc
       real(wp), allocatable :: amat(:, :)
       real(wp), allocatable :: vvec(:)
@@ -61,6 +62,7 @@ subroutine update(self, mol)
    if (any(mol%periodic)) then
       call new_wignerseitz_cell(self%wsc, mol)
       call get_alpha(mol%lattice, self%alpha, .false.)
+      call get_alpha(mol%lattice, self%alpha_multipole, .true.)
    end if
 
 end subroutine update

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -685,7 +685,9 @@ pure subroutine get_amat_sdq_dir_3d(rij, rr, kdmp3, kdmp5, alp, trans, &
 
       tmp = fdmp3 * g3 + e1
       amat_sd = amat_sd + vec * tmp
-      amat_dd(:, :) = amat_dd(:, :) + unity * tmp
+      amat_dd(1, 1) = amat_dd(1, 1) + tmp
+      amat_dd(2, 2) = amat_dd(2, 2) + tmp
+      amat_dd(3, 3) = amat_dd(3, 3) + tmp
       tmp = fdmp5 * g5 + e2
       amat_dd(:, 1) = amat_dd(:, 1) - vec * vec(1) * (3 * tmp)
       amat_dd(:, 2) = amat_dd(:, 2) - vec * vec(2) * (3 * tmp)

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -430,7 +430,8 @@ subroutine get_dir_trans(lattice, alpha, conv, trans)
    !> Translation vectors
    real(wp), allocatable, intent(out) :: trans(:, :)
 
-   call get_lattice_points([.true.], lattice, get_dir_cutoff(alpha, conv), trans)
+   ! call get_lattice_points([.true.], lattice, get_dir_cutoff(alpha, conv), trans)
+   call get_lattice_points([.true.], lattice, 100.0_wp, trans)
 
 end subroutine get_dir_trans
 
@@ -451,7 +452,6 @@ subroutine get_rec_trans(lattice, alpha, volume, conv, trans)
 
    rec_lat = twopi*transpose(matinv_3x3(lattice))
    call get_lattice_points([.true.], rec_lat, get_rec_cutoff(alpha, volume, conv), trans)
-   trans = trans(:, 2:)
 
 end subroutine get_rec_trans
 
@@ -476,7 +476,7 @@ subroutine get_multipole_matrix(self, mol, cache, amat_sd, amat_dd, amat_sq)
    amat_sq(:, :, :) = 0.0_wp
    if (any(mol%periodic)) then
       call get_multipole_matrix_3d(mol, cache%mrad, self%kdmp3, self%kdmp5, &
-         & cache%wsc, cache%alpha, amat_sd, amat_dd, amat_sq)
+         & cache%alpha_multipole, amat_sd, amat_dd, amat_sq)
    else
       call get_multipole_matrix_0d(mol, cache%mrad, self%kdmp3, self%kdmp5, &
          & amat_sd, amat_dd, amat_sq)
@@ -534,7 +534,7 @@ subroutine get_multipole_matrix_0d(mol, rad, kdmp3, kdmp5, amat_sd, amat_dd, ama
 end subroutine get_multipole_matrix_0d
 
 !> Evaluate multipole interaction matrix under 3D periodic boundary conditions
-subroutine get_multipole_matrix_3d(mol, rad, kdmp3, kdmp5, wsc, alpha, &
+subroutine get_multipole_matrix_3d(mol, rad, kdmp3, kdmp5, alpha, &
       & amat_sd, amat_dd, amat_sq)
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
@@ -544,8 +544,6 @@ subroutine get_multipole_matrix_3d(mol, rad, kdmp3, kdmp5, wsc, alpha, &
    real(wp), intent(in) :: kdmp3
    !> Damping function for inverse cubic contributions
    real(wp), intent(in) :: kdmp5
-   !> Wigner-Seitz cell images
-   type(wignerseitz_cell), intent(in) :: wsc
    !> Convergence parameter for Ewald sum
    real(wp), intent(in) :: alpha
    !> Interation matrix for charges and dipoles
@@ -555,8 +553,8 @@ subroutine get_multipole_matrix_3d(mol, rad, kdmp3, kdmp5, wsc, alpha, &
    !> Interation matrix for charges and quadrupoles
    real(wp), intent(inout) :: amat_sq(:, :, :)
 
-   integer :: iat, jat, img, k
-   real(wp) :: vec(3), rr, wsw, vol
+   integer :: iat, jat, k
+   real(wp) :: vec(3), rr, vol
    real(wp) :: d_sd(3), d_dd(3, 3), d_sq(6), r_sd(3), r_dd(3, 3), r_sq(6)
    real(wp), allocatable :: dtrans(:, :), rtrans(:, :)
 
@@ -566,22 +564,19 @@ subroutine get_multipole_matrix_3d(mol, rad, kdmp3, kdmp5, wsc, alpha, &
 
    !$omp parallel do default(none) schedule(runtime) collapse(2) &
    !$omp shared(amat_sd, amat_dd, amat_sq) &
-   !$omp shared(mol, wsc, rad, vol, alpha, rtrans, dtrans, kdmp3, kdmp5) &
-   !$omp private(iat, jat, img, vec, rr, wsw, d_sd, d_dd, d_sq, r_sd, r_dd, r_sq)
+   !$omp shared(mol, rad, vol, alpha, rtrans, dtrans, kdmp3, kdmp5) &
+   !$omp private(iat, jat, vec, rr, d_sd, d_dd, d_sq, r_sd, r_dd, r_sq)
    do iat = 1, mol%nat
       do jat = 1, mol%nat
-         wsw = 1.0_wp / real(wsc%nimg(jat, iat), wp)
-         do img = 1, wsc%nimg(jat, iat)
-            vec = mol%xyz(:, iat) - mol%xyz(:, jat) - wsc%trans(:, wsc%tridx(img, jat, iat))
+         vec = mol%xyz(:, iat) - mol%xyz(:, jat)
 
-            rr = 0.5_wp * (rad(jat) + rad(iat))
-            call get_amat_sdq_rec_3d(vec, vol, alpha, rtrans, r_sd, r_dd, r_sq)
-            call get_amat_sdq_dir_3d(vec, rr, kdmp3, kdmp5, alpha, dtrans, d_sd, d_dd, d_sq)
+         rr = 0.5_wp * (rad(jat) + rad(iat))
+         call get_amat_sdq_rec_3d(vec, vol, alpha, rtrans, r_sd, r_dd, r_sq)
+         call get_amat_sdq_dir_3d(vec, rr, kdmp3, kdmp5, alpha, dtrans, d_sd, d_dd, d_sq)
 
-            amat_sd(:, jat, iat) = amat_sd(:, jat, iat) + wsw * (d_sd + r_sd)
-            amat_dd(:, jat, :, iat) = amat_dd(:, jat, :, iat) + wsw * (r_dd + d_dd)
-            amat_sq(:, jat, iat) = amat_sq(:, jat, iat) + wsw * (r_sq + d_sq)
-         end do
+         amat_sd(:, jat, iat) = amat_sd(:, jat, iat) + (d_sd + r_sd)
+         amat_dd(:, jat, :, iat) = amat_dd(:, jat, :, iat) + (r_dd + d_dd)
+         amat_sq(:, jat, iat) = amat_sq(:, jat, iat) + (r_sq + d_sq)
       end do
    end do
 
@@ -611,17 +606,19 @@ pure subroutine get_amat_sdq_rec_3d(rij, vol, alp, trans, amat_sd, amat_dd, amat
    real(wp), intent(out) :: amat_sq(:)
 
    integer :: itr
-   real(wp) :: fac, vec(3), g2, expk, sink, cosk, gv
+   real(wp) :: fac, vec(3), g2, expk, sink, cosk, gv, rtmp, k_q(6)
 
    amat_sd = 0.0_wp
    amat_dd = 0.0_wp
    amat_sq = 0.0_wp
    fac = 4*pi/vol
 
-   amat_dd(1, 1) = fac/6.0_wp
-   amat_dd(2, 2) = fac/6.0_wp
-   amat_dd(3, 3) = fac/6.0_wp
-   amat_sq([1, 3, 6]) = -fac/9.0_wp
+   ! Not needed assuming conducting boundary conditions
+   ! which is reasonable assuming tblite supports 3d pbc only
+   ! amat_dd(1, 1) = fac/6.0_wp
+   ! amat_dd(2, 2) = fac/6.0_wp
+   ! amat_dd(3, 3) = fac/6.0_wp
+   ! amat_sq([1, 3, 6]) = -fac/9.0_wp
 
    do itr = 1, size(trans, 2)
       vec(:) = trans(:, itr)
@@ -632,14 +629,17 @@ pure subroutine get_amat_sdq_rec_3d(rij, vol, alp, trans, amat_sd, amat_dd, amat
       sink = sin(gv)*expk
       cosk = cos(gv)*expk
 
-      amat_sd(:) = amat_sd + 2*vec*sink
+      ! packed quadratic basis
+      k_q(1) =          vec(1) * vec(1)
+      k_q(2) = 2.0_wp * vec(1) * vec(2)
+      k_q(3) =          vec(2) * vec(2)
+      k_q(4) = 2.0_wp * vec(1) * vec(3)
+      k_q(5) = 2.0_wp * vec(2) * vec(3)
+      k_q(6) =          vec(3) * vec(3)
+
+      amat_sd(:) = amat_sd + vec * sink
       amat_dd(:, :) = amat_dd + spread(vec, 1, 3) * spread(vec, 2, 3) * cosk
-      amat_sq(1) = amat_sq(1) +   vec(1)*vec(1)*cosk
-      amat_sq(2) = amat_sq(2) + 2*vec(1)*vec(2)*cosk
-      amat_sq(3) = amat_sq(3) +   vec(2)*vec(2)*cosk
-      amat_sq(4) = amat_sq(4) + 2*vec(1)*vec(3)*cosk
-      amat_sq(5) = amat_sq(5) + 2*vec(2)*vec(3)*cosk
-      amat_sq(6) = amat_sq(6) +   vec(3)*vec(3)*cosk
+      amat_sq(:) = amat_sq - cosk / 3.0_wp * k_q
    end do
 
 end subroutine get_amat_sdq_rec_3d
@@ -719,7 +719,7 @@ subroutine get_multipole_gradient(self, mol, cache, qat, dpat, qpat, dEdr, gradi
 
    if (any(mol%periodic)) then
       call get_multipole_gradient_3d(mol, cache%mrad, self%kdmp3, self%kdmp5, &
-         & qat, dpat, qpat, cache%wsc, cache%alpha, dEdr, gradient, sigma)
+         & qat, dpat, qpat, cache%alpha_multipole, dEdr, gradient, sigma)
    else
       call get_multipole_gradient_0d(mol, cache%mrad, self%kdmp3, self%kdmp5, &
          & qat, dpat, qpat, dEdr, gradient, sigma)
@@ -836,7 +836,7 @@ subroutine get_multipole_gradient_0d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, &
 end subroutine get_multipole_gradient_0d
 
 !> Evaluate multipole derivatives under 3D periodic boundary conditions
-subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, wsc, alpha, &
+subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, alpha, &
       & dEdr, gradient, sigma)
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
@@ -852,8 +852,6 @@ subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, ws
    real(wp), contiguous, intent(in) :: dpat(:, :)
    !> Atomic quadrupole moments
    real(wp), contiguous, intent(in) :: qpat(:, :)
-   !> Wigner-Seitz cell images
-   type(wignerseitz_cell), intent(in) :: wsc
    !> Convergence parameter for Ewald sum
    real(wp), intent(in) :: alpha
    !> Derivative of the energy w.r.t. the critical radii
@@ -865,7 +863,7 @@ subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, ws
 
    integer :: iat, jat, img
    real(wp) :: vec(3), dG(3), dGr(3), dGd(3), dS(3, 3), dSr(3, 3), dSd(3, 3)
-   real(wp) :: wsw, vol, rr, dE, dEd
+   real(wp) :: wsw, vol, rr, dE
    real(wp), allocatable :: dtrans(:, :), rtrans(:, :)
 
    vol = abs(matdet_3x3(mol%lattice))
@@ -873,26 +871,24 @@ subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, ws
    call get_rec_trans(mol%lattice, alpha, vol, conv, rtrans)
 
    !$omp parallel do default(none) schedule(runtime) reduction(+:dEdr, gradient, sigma) &
-   !$omp shared(mol, wsc, kdmp3, kdmp5, vol, alpha, rtrans, dtrans, rad, qat, dpat, qpat) &
-   !$omp private(iat, jat, dE, dG, dS, wsw, img, vec, rr, dEd, dGd, dGr, dSd, dSr)
+   !$omp shared(mol, kdmp3, kdmp5, vol, alpha, rtrans, dtrans, rad, qat, dpat, qpat) &
+   !$omp private(iat, jat, dE, dG, dS, vec, rr, dGd, dGr, dSd, dSr)
    do iat = 1, mol%nat
       do jat = 1, iat - 1
          dE = 0.0_wp
          dG(:) = 0.0_wp
          dS(:, :) = 0.0_wp
-         wsw = 1.0_wp / real(wsc%nimg(jat, iat), wp)
-         do img = 1, wsc%nimg(jat, iat)
-            vec(:) = mol%xyz(:, jat)-mol%xyz(:, iat) + wsc%trans(:, wsc%tridx(img, jat, iat))
-            rr = 0.5_wp * (rad(jat) + rad(iat))
 
-            call get_damat_sdq_rec_3d(vec, qat(iat), qat(jat), dpat(:, iat), dpat(:, jat), &
-               & qpat(:, iat), qpat(:, jat), vol, alpha, rtrans, dGr, dSr)
-            call get_damat_sdq_dir_3d(vec, qat(iat), qat(jat), dpat(:, iat), dpat(:, jat), &
-               & qpat(:, iat), qpat(:, jat), rr, kdmp3, kdmp5, alpha, dtrans, dEd, dGd, dSd)
-            dE = dE + dEd * wsw
-            dG = dG + (dGd + dGr) * wsw
-            dS = dS + (dSd + dSr) * wsw
-         end do
+         vec(:) = mol%xyz(:, jat) - mol%xyz(:, iat)
+         rr = 0.5_wp * (rad(jat) + rad(iat))
+
+         call get_damat_sdq_rec_3d(vec, qat(iat), qat(jat), dpat(:, iat), dpat(:, jat), &
+            & qpat(:, iat), qpat(:, jat), vol, alpha, rtrans, dGr, dSr)
+         call get_damat_sdq_dir_3d(vec, qat(iat), qat(jat), dpat(:, iat), dpat(:, jat), &
+            & qpat(:, iat), qpat(:, jat), rr, kdmp3, kdmp5, alpha, dtrans, dE, dGd, dSd)
+         dG = (dGd + dGr)
+         dS = (dSd + dSr)
+
          dEdr(iat) = dEdr(iat) + dE
          dEdr(jat) = dEdr(jat) + dE
          gradient(:, iat) = gradient(:, iat) + dG
@@ -902,23 +898,21 @@ subroutine get_multipole_gradient_3d(mol, rad, kdmp3, kdmp5, qat, dpat, qpat, ws
    end do
 
    !$omp parallel do default(none) schedule(runtime) reduction(+:dEdr, sigma) &
-   !$omp shared(mol, wsc, kdmp3, kdmp5, vol, alpha, rtrans, dtrans, rad, qat, dpat, qpat) &
-   !$omp private(iat, jat, dE, dG, dS, wsw, img, vec, rr, dEd, dGd, dGr, dSd, dSr)
+   !$omp shared(mol, kdmp3, kdmp5, vol, alpha, rtrans, dtrans, rad, qat, dpat, qpat) &
+   !$omp private(iat, jat, dE, dG, dS, vec, rr, dGd, dGr, dSd, dSr)
    do iat = 1, mol%nat
       dE = 0.0_wp
       dS(:, :) = 0.0_wp
-      wsw = 1.0_wp / real(wsc%nimg(iat, iat), wp)
-      do img = 1, wsc%nimg(iat, iat)
-         vec(:) = wsc%trans(:, wsc%tridx(img, iat, iat))
-         rr = rad(iat)
 
-         call get_damat_sdq_rec_3d(vec, qat(iat), qat(iat), dpat(:, iat), dpat(:, iat), &
-            & qpat(:, iat), qpat(:, iat), vol, alpha, rtrans, dGr, dSr)
-         call get_damat_sdq_dir_3d(vec, qat(iat), qat(iat), dpat(:, iat), dpat(:, iat), &
-            & qpat(:, iat), qpat(:, iat), rr, kdmp3, kdmp5, alpha, dtrans, dEd, dGd, dSd)
-         dE = dE + dEd * wsw
-         dS = dS + (dSd + dSr) * wsw
-      end do
+      vec(:) = 0.0_wp
+      rr = rad(iat)
+
+      call get_damat_sdq_rec_3d(vec, qat(iat), qat(iat), dpat(:, iat), dpat(:, iat), &
+         & qpat(:, iat), qpat(:, iat), vol, alpha, rtrans, dGr, dSr)
+      call get_damat_sdq_dir_3d(vec, qat(iat), qat(iat), dpat(:, iat), dpat(:, iat), &
+         & qpat(:, iat), qpat(:, iat), rr, kdmp3, kdmp5, alpha, dtrans, dE, dGd, dSd)
+      dS = (dSd + dSr)
+
       dEdr(iat) = dEdr(iat) + dE
       sigma = sigma + 0.5_wp * dS
    end do
@@ -954,12 +948,12 @@ pure subroutine get_damat_sdq_rec_3d(rij, qi, qj, mi, mj, ti, tj, vol, alp, tran
       dpiqj = dot_product(vec, mi)*qj
       qidpj = dot_product(vec, mj)*qi
 
-      dg(:) = dg - 2*vec*cosk * (dpiqj - qidpj)
+      dg(:) = dg - vec*cosk * (dpiqj - qidpj)
       do b = 1, 3
          do a = 1, 3
             ds(a, b) = ds(a, b) &
-               & + 2 * sink * (dpiqj - qidpj) * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(a)*vec(b) - unity(a, b)) &
-               & - sink*(vec(a)*(qj*mi(b) - qi*mj(b)) + vec(b)*(qj*mi(a) - qi*mj(a)))
+               & + sink * (dpiqj - qidpj) * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(a)*vec(b) - unity(a, b)) &
+               & - 0.5_wp*sink*(vec(a)*(qj*mi(b) - qi*mj(b)) + vec(b)*(qj*mi(a) - qi*mj(a)))
          end do
       end do
 
@@ -986,12 +980,12 @@ pure subroutine get_damat_sdq_rec_3d(rij, qi, qj, mi, mj, ti, tj, vol, alp, tran
          & tj(2)*vec(1) + tj(3)*vec(2) + tj(5)*vec(3), &
          & tj(4)*vec(1) + tj(5)*vec(2) + tj(6)*vec(3)]
 
-      dg(:) = dg + vec * sink * (qiqpj + qpiqj)
+      dg(:) = dg - (vec * sink * (qiqpj + qpiqj)) / 3.0_wp
       do b = 1, 3
          do a = 1, 3
             ds(a, b) = ds(a, b) &
-               & + cosk * (qiqpj + qpiqj) * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(a)*vec(b) - unity(a, b)) &
-               & - cosk*(vec(a)*(qi*tjv(b) + qj*tiv(b)) + vec(b)*(qi*tjv(a) + qj*tiv(a)))
+               & - (cosk * (qiqpj + qpiqj) * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(a)*vec(b) - unity(a, b))) / 3.0_wp &
+               & + (cosk*(vec(a)*(qi*tjv(b) + qj*tiv(b)) + vec(b)*(qi*tjv(a) + qj*tiv(a)))) / 3.0_wp
          end do
       end do
    end do

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -638,7 +638,9 @@ pure subroutine get_amat_sdq_rec_3d(rij, vol, alp, trans, amat_sd, amat_dd, amat
       k_q(6) =          vec(3) * vec(3)
 
       amat_sd(:) = amat_sd + vec * sink
-      amat_dd(:, :) = amat_dd + spread(vec, 1, 3) * spread(vec, 2, 3) * cosk
+      amat_dd(:, 1) = amat_dd + vec * vec(1) * cosk
+      amat_dd(:, 2) = amat_dd + vec * vec(2) * cosk
+      amat_dd(:, 3) = amat_dd + vec * vec(3) * cosk
       amat_sq(:) = amat_sq - cosk / 3.0_wp * k_q
    end do
 
@@ -683,8 +685,11 @@ pure subroutine get_amat_sdq_dir_3d(rij, rr, kdmp3, kdmp5, alp, trans, &
 
       tmp = fdmp3 * g3 + e1
       amat_sd = amat_sd + vec * tmp
-      amat_dd(:, :) = amat_dd(:, :) + unity * (fdmp5*g3 + e1) &
-         & - spread(vec, 1, 3) * spread(vec, 2, 3) * (3 * (g5*fdmp5 + e2))
+      amat_dd(:, :) = amat_dd(:, :) + unity * tmp
+      tmp = fdmp5 * g5 + e2
+      amat_dd(:, 1) = amat_dd(:, 1) - vec * vec(1) * (3 * tmp)
+      amat_dd(:, 2) = amat_dd(:, 2) - vec * vec(2) * (3 * tmp)
+      amat_dd(:, 3) = amat_dd(:, 3) - vec * vec(3) * (3 * tmp)
       amat_sq(1) = amat_sq(1) +   vec(1)*vec(1)*(g5*fdmp5 + e2) - (fdmp5*g3 + e1)/3.0_wp
       amat_sq(2) = amat_sq(2) + 2*vec(1)*vec(2)*(g5*fdmp5 + e2)
       amat_sq(3) = amat_sq(3) +   vec(2)*vec(2)*(g5*fdmp5 + e2) - (fdmp5*g3 + e1)/3.0_wp

--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -638,9 +638,9 @@ pure subroutine get_amat_sdq_rec_3d(rij, vol, alp, trans, amat_sd, amat_dd, amat
       k_q(6) =          vec(3) * vec(3)
 
       amat_sd(:) = amat_sd + vec * sink
-      amat_dd(:, 1) = amat_dd + vec * vec(1) * cosk
-      amat_dd(:, 2) = amat_dd + vec * vec(2) * cosk
-      amat_dd(:, 3) = amat_dd + vec * vec(3) * cosk
+      amat_dd(:, 1) = amat_dd(:, 1) + vec * vec(1) * cosk
+      amat_dd(:, 2) = amat_dd(:, 2) + vec * vec(2) * cosk
+      amat_dd(:, 3) = amat_dd(:, 3) + vec * vec(3) * cosk
       amat_sq(:) = amat_sq - cosk / 3.0_wp * k_q
    end do
 

--- a/test/unit/test_coulomb_multipole.f90
+++ b/test/unit/test_coulomb_multipole.f90
@@ -86,9 +86,9 @@ subroutine collect_coulomb_multipole(testsuite)
       new_unittest("energy-pbc", test_e_effective_co2), &
       new_unittest("energy-pbc-qp", test_e_effective_co2_qp), &
       new_unittest("energy-pbc-dp", test_e_effective_co2_dp), &
-      !new_unittest("energy-sc", test_e_effective_co2_sc), &
-      !new_unittest("energy-sc-qp", test_e_effective_co2_sc_qp), &
-      !new_unittest("energy-sc-dp", test_e_effective_co2_sc_dp), &
+      new_unittest("energy-sc", test_e_effective_co2_sc), &
+      new_unittest("energy-sc-qp", test_e_effective_co2_sc_qp), &
+      new_unittest("energy-sc-dp", test_e_effective_co2_sc_dp), &
       new_unittest("gradient-1", test_g_effective_m03), &
       new_unittest("gradient-2", test_g_effective_m04), &
       new_unittest("gradient-pbc", test_g_effective_urea), &
@@ -185,7 +185,7 @@ subroutine view(cache, ptr)
 end subroutine view
 
 
-subroutine test_generic(error, mol, qat, dpat, qpat, make_multipole, ref)
+subroutine test_generic(error, mol, qat, dpat, qpat, make_multipole, ref, thr_in)
 
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
@@ -208,18 +208,20 @@ subroutine test_generic(error, mol, qat, dpat, qpat, make_multipole, ref)
    !> Reference value to check against
    real(wp), intent(in) :: ref
 
+   !> Test threshold
+   real(wp), intent(in), optional :: thr_in
+
    type(damped_multipole) :: multipole
    type(container_cache) :: cache
    type(coulomb_cache), pointer :: ccache
-   real(wp) :: energy(mol%nat), sigma(3, 3)
-   real(wp), allocatable :: gradient(:, :), numgrad(:, :)
-   real(wp), parameter :: step = 1.0e-6_wp
+   real(wp) :: energy(mol%nat)
+   real(wp) :: thr_
    type(wavefunction_type) :: wfn
 
-   allocate(gradient(3, mol%nat), numgrad(3, mol%nat))
+   thr_ = thr
+   if (present(thr_in)) thr_ = thr_in
+
    energy = 0.0_wp
-   gradient(:, :) = 0.0_wp
-   sigma(:, :) = 0.0_wp
    wfn%qat = reshape(qat, [size(qat), 1])
    wfn%dpat = reshape(dpat, [shape(dpat), 1])
    wfn%qpat = reshape(qpat, [shape(qpat), 1])
@@ -230,7 +232,7 @@ subroutine test_generic(error, mol, qat, dpat, qpat, make_multipole, ref)
    call multipole%update(mol, cache)
    call multipole%get_energy(mol, cache, wfn, energy)
 
-   call check(error, sum(energy), ref, thr=thr)
+   call check(error, sum(energy), ref, thr=thr_)
    if (allocated(error)) then
       print *, ref, sum(energy)
    end if
@@ -1098,7 +1100,7 @@ subroutine test_s_effective_oxacb(error)
       & shape(qpat))
 
    call get_structure(mol, "X23", "oxacb")
-   call test_numsigma(error, mol, qat, dpat, qpat, make_multipole2, 1.0e-6_wp)
+   call test_numsigma(error, mol, qat, dpat, qpat, make_multipole2)
 
 end subroutine test_s_effective_oxacb
 
@@ -1301,9 +1303,6 @@ submodule (test_coulomb_multipole) test_supercell_scaling
       & -1.18646463864190E-01_wp,  1.18587233297690E-01_wp,  1.19626167010667E-04_wp],&
       & shape(qpat1))
 
-   real(wp), parameter :: e02 = 1.5016169607148633E-2_wp, e11 = -3.5486703953320990E-3_wp, &
-      & e01 = 1.5706712259423678E-2_wp - e02 - e11
-
 contains
 
 module subroutine test_e_effective_co2(error)
@@ -1317,7 +1316,8 @@ module subroutine test_e_effective_co2(error)
    real(wp), parameter :: qpat(6, nat) = qpat1
 
    call get_structure(mol, "X23", "CO2")
-   call test_generic(error, mol, qat, dpat, qpat, make_multipole2, e01+e02+e11)
+   call test_generic(error, mol, qat, dpat, qpat, make_multipole2, &
+      & 1.1845154012941148E-002_wp)
 end subroutine test_e_effective_co2
 
 module subroutine test_e_effective_co2_dp(error)
@@ -1331,7 +1331,8 @@ module subroutine test_e_effective_co2_dp(error)
    real(wp), parameter :: qpat0(6, nat) = 0.0_wp
 
    call get_structure(mol, "X23", "CO2")
-   call test_generic(error, mol, qat0, dpat, qpat0, make_multipole2, e11)
+   call test_generic(error, mol, qat0, dpat, qpat0, make_multipole2, &
+      & -3.5484081927304499E-003_wp)
 end subroutine test_e_effective_co2_dp
 
 module subroutine test_e_effective_co2_qp(error)
@@ -1345,7 +1346,8 @@ module subroutine test_e_effective_co2_qp(error)
    real(wp), parameter :: qpat(6, nat) = qpat1
 
    call get_structure(mol, "X23", "CO2")
-   call test_generic(error, mol, qat, dpat0, qpat, make_multipole2, e02)
+   call test_generic(error, mol, qat, dpat0, qpat, make_multipole2, &
+      & 1.4924274826882175E-002_wp)
 end subroutine test_e_effective_co2_qp
 
 
@@ -1355,17 +1357,10 @@ module subroutine test_e_effective_co2_sc(error)
    type(error_type), allocatable, intent(out) :: error
 
    type(structure_type) :: mol
-   integer, parameter :: supercell(3) = [2, 2, 2]
-   integer, parameter :: nsc = product(supercell)
-   real(wp), parameter :: qat(nsc*nat) = [spread(qat1, 2, nsc)]
-   real(wp), parameter :: dpat(3, nsc*nat) = &
-      & reshape([dpat1, dpat1, dpat1, dpat1, dpat1, dpat1, dpat1, dpat1], shape(dpat))
-   real(wp), parameter :: qpat(6, nsc*nat) = &
-      & reshape([qpat1, qpat1, qpat1, qpat1, qpat1, qpat1, qpat1, qpat1], shape(qpat))
 
    call get_structure(mol, "X23", "CO2")
-   call make_supercell(mol, supercell)
-   call test_generic(error, mol, qat, dpat, qpat, make_multipole2, product(supercell)*(e01+e02+e11))
+   call test_energy_sc(error, mol, qat1, dpat1, qpat1, [2, 2, 2], &
+      & make_multipole2, thr_in=100*thr2)
 end subroutine test_e_effective_co2_sc
 
 
@@ -1375,16 +1370,12 @@ module subroutine test_e_effective_co2_sc_dp(error)
    type(error_type), allocatable, intent(out) :: error
 
    type(structure_type) :: mol
-   integer, parameter :: supercell(3) = [2, 2, 2]
-   integer, parameter :: nsc = product(supercell)
-   real(wp), parameter :: qat0(nsc*nat) = 0.0_wp
-   real(wp), parameter :: dpat(3, nsc*nat) = &
-      & reshape([dpat1, dpat1, dpat1, dpat1, dpat1, dpat1, dpat1, dpat1], shape(dpat))
-   real(wp), parameter :: qpat0(6, nsc*nat) = 0.0_wp
+   real(wp), parameter :: qat0(nat) = 0.0_wp
+   real(wp), parameter :: qpat0(6, nat) = 0.0_wp
 
    call get_structure(mol, "X23", "CO2")
-   call make_supercell(mol, supercell)
-   call test_generic(error, mol, qat0, dpat, qpat0, make_multipole2, product(supercell)*e11)
+   call test_energy_sc(error, mol, qat0, dpat1, qpat0, [2, 2, 2], &
+      & make_multipole2, thr_in=10*thr2)
 end subroutine test_e_effective_co2_sc_dp
 
 
@@ -1394,17 +1385,116 @@ module subroutine test_e_effective_co2_sc_qp(error)
    type(error_type), allocatable, intent(out) :: error
 
    type(structure_type) :: mol
-   integer, parameter :: supercell(3) = [2, 2, 2]
-   integer, parameter :: nsc = product(supercell)
-   real(wp), parameter :: qat(nsc*nat) = [spread(qat1, 2, nsc)]
-   real(wp), parameter :: dpat0(3, nsc*nat) = 0.0_wp
-   real(wp), parameter :: qpat(6, nsc*nat) = &
-      & reshape([qpat1, qpat1, qpat1, qpat1, qpat1, qpat1, qpat1, qpat1], shape(qpat))
+   real(wp), parameter :: dpat0(3, nat) = 0.0_wp
 
    call get_structure(mol, "X23", "CO2")
-   call make_supercell(mol, supercell)
-   call test_generic(error, mol, qat, dpat0, qpat, make_multipole2, product(supercell)*e02)
+   call test_energy_sc(error, mol, qat1, dpat0, qpat1, [2, 2, 2], &
+      & make_multipole2, thr_in=thr2)
 end subroutine test_e_effective_co2_sc_qp
+
+
+!> Evaluate the multipole energy and return its value without comparing to a reference.
+!> Used to dynamically obtain a unit cell energy for supercell scaling checks.
+subroutine compute_energy(error, mol, qat, dpat, qpat, make_multipole, energy_out)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   !> Molecular structure data
+   type(structure_type), intent(inout) :: mol
+
+   !> Atomic partial charges for this structure
+   real(wp), contiguous, intent(in) :: qat(:)
+
+   !> Atomic dipole moments for this structure
+   real(wp), contiguous, intent(in) :: dpat(:, :)
+
+   !> Atomic quadrupole moments for this structure
+   real(wp), contiguous, intent(in) :: qpat(:, :)
+
+   !> Factory to create new electrostatic objects
+   procedure(multipole_maker) :: make_multipole
+
+   !> Total energy of the system
+   real(wp), intent(out) :: energy_out
+
+   type(damped_multipole) :: multipole
+   type(container_cache) :: cache
+   type(coulomb_cache), pointer :: ccache
+   type(wavefunction_type) :: wfn
+   real(wp), allocatable :: energy(:)
+
+   allocate(energy(mol%nat))
+   energy = 0.0_wp
+   wfn%qat = reshape(qat, [size(qat), 1])
+   wfn%dpat = reshape(dpat, [shape(dpat), 1])
+   wfn%qpat = reshape(qpat, [shape(qpat), 1])
+   call taint(cache, ccache)
+   call ccache%update(mol)
+   call make_multipole(multipole, mol, error)
+   if (allocated(error)) return
+   call multipole%update(mol, cache)
+   call multipole%get_energy(mol, cache, wfn, energy)
+   energy_out = sum(energy)
+
+end subroutine compute_energy
+
+
+!> Generic supercell scaling test for multipole electrostatics.
+!> Dynamically computes the unit cell energy, builds a supercell,
+!> and checks that the supercell energy equals nsc * unit_cell_energy.
+subroutine test_energy_sc(error, mol, qat, dpat, qpat, supercell, make_multipole, thr_in)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   !> Molecular structure data (unit cell, will be modified)
+   type(structure_type), intent(inout) :: mol
+
+   !> Atomic partial charges for the unit cell
+   real(wp), contiguous, intent(in) :: qat(:)
+
+   !> Atomic dipole moments for the unit cell
+   real(wp), contiguous, intent(in) :: dpat(:, :)
+
+   !> Atomic quadrupole moments for the unit cell
+   real(wp), contiguous, intent(in) :: qpat(:, :)
+
+   !> Supercell replication factors along each lattice vector
+   integer, intent(in) :: supercell(3)
+
+   !> Factory to create new electrostatic objects
+   procedure(multipole_maker) :: make_multipole
+
+   !> Test threshold
+   real(wp), intent(in), optional :: thr_in
+
+   type(structure_type) :: mol_sc
+   integer :: nsc, nat_uc
+   real(wp) :: eref
+   real(wp), allocatable :: qat_sc(:), dpat_sc(:,:), qpat_sc(:,:)
+
+   nsc = product(supercell)
+   nat_uc = mol%nat
+
+   !> Compute unit cell energy as reference
+   call compute_energy(error, mol, qat, dpat, qpat, make_multipole, eref)
+   if (allocated(error)) return
+
+   !> Tile multipole moments over the supercell
+   qat_sc = [spread(qat, 2, nsc)]
+   dpat_sc = reshape(spread(dpat, 3, nsc), [3, nat_uc * nsc])
+   qpat_sc = reshape(spread(qpat, 3, nsc), [6, nat_uc * nsc])
+
+   !> Build supercell
+   mol_sc = mol
+   call make_supercell(mol_sc, supercell)
+
+   !> Compute supercell energy and compare
+   call test_generic(error, mol_sc, qat_sc, dpat_sc, qpat_sc, make_multipole, &
+      & nsc * eref, thr_in)
+
+end subroutine test_energy_sc
 
 
 subroutine make_supercell(mol, rep)


### PR DESCRIPTION
The old implementation had formal errors in the reciprocal space contributions:
1. it assumed rtrans included only +k and not -k
2. the charge-quadrupole didn't use the correct quadrupole prefactor
Accordingly, the reciprocal space contributions to the gradients and virials were also incorrect. This is corrected now.

Furthermore, the damping function introduces an algebraically decaying tail, which converges too slowly to use the same cutoff radius as the Ewald summation. I just set a high threshold for the real space cutoff which usually means that the sum converges to ~10e-7 accuracy. This introduces some overhead compared to previous calculations, however. The question is if we should just accept this or choose a shorter cutoff and accept higher errors (which would still require probably ~50 bohr cutoff radius to converge below mHartree accuracy).

What I also removed were the surface energy terms, which should be irrelevant considering that tblite only supports 3d pbc and conducting boundaries shouldn't introduce any errors.

Finally, I got rid of the usage of the minimum image convention/CCM since it doesn't make sense to use it like this here.

I enabled all unit tests and updated the scaling tests to calculate the energies dynamically, which is less prone to breaking on updates and targets the scaling more specifically. Also, the virials now converge to an acceptable accuracy. 