### PR TITLE
CMake: Disable BUILD_TESTING for toml-f when WITH_TEST=OFF

### DIFF
--- a/config/cmake/Findtoml-f.cmake
+++ b/config/cmake/Findtoml-f.cmake
@@ -30,6 +30,12 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/tblite-utils.cmake")
 
+if(NOT WITH_TESTS)
+  # toml-f uses BUILD_TESTING instead of WITH_TESTS.
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+  set(BUILD_TESTING OFF)
+endif()
+
 tblite_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}" "${_rev}")
 
 if(DEFINED "_${_pkg}_FIND_METHOD")

--- a/config/cmake/Findtoml-f.cmake
+++ b/config/cmake/Findtoml-f.cmake
@@ -30,7 +30,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/tblite-utils.cmake")
 
-if(NOT WITH_TESTS)
+if(NOT TBLITE_WITH_TESTS)
   # toml-f uses BUILD_TESTING instead of WITH_TESTS.
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   set(BUILD_TESTING OFF)


### PR DESCRIPTION
Package `toml-f` use a more general option name, `BUILD_TESTING`, rather than `WITH_TESTS`. Therefore, `WITH_TESTS=OFF` flag won't be passed to `toml-f`, and `toml-f` will keep building unittests. This PR fixes the behavior.