### PR TITLE
Fix periodic dipole-dipole damping exponent

### DIFF
--- a/src/tblite/coulomb/multipole.f90
+++ b/src/tblite/coulomb/multipole.f90
@@ -685,6 +685,7 @@ pure subroutine get_amat_sdq_dir_3d(rij, rr, kdmp3, kdmp5, alp, trans, &
 
       tmp = fdmp3 * g3 + e1
       amat_sd = amat_sd + vec * tmp
+      tmp = fdmp5 * g3 + e1
       amat_dd(1, 1) = amat_dd(1, 1) + tmp
       amat_dd(2, 2) = amat_dd(2, 2) + tmp
       amat_dd(3, 3) = amat_dd(3, 3) + tmp

--- a/test/unit/test_coulomb_multipole.f90
+++ b/test/unit/test_coulomb_multipole.f90
@@ -147,6 +147,25 @@ subroutine make_multipole2(multipole, mol, error)
 end subroutine make_multipole2
 
 
+!> Factory with distinct inverse-cubic and inverse-quintic GFN2 damping exponents
+subroutine make_multipole2_dmp5(multipole, mol, error)
+
+   !> New electrostatic object
+   type(damped_multipole), intent(out) :: multipole
+
+   !> Molecular structure data
+   type(structure_type), intent(in) :: mol
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call make_multipole2(multipole, mol, error)
+   if (allocated(error)) return
+   multipole%kdmp5 = 4.0_wp
+
+end subroutine make_multipole2_dmp5
+
+
 !> Inspect container cache and reallocate it in case of type mismatch
 subroutine taint(cache, ptr)
    !> Instance of the container cache
@@ -957,6 +976,8 @@ subroutine test_s_effective_m05(error)
 
    call get_structure(mol, "MB16-43", "05")
    call test_numsigma(error, mol, qat, dpat, qpat, make_multipole2)
+   if (allocated(error)) return
+   call test_numsigma(error, mol, qat, dpat, qpat, make_multipole2_dmp5)
 
 end subroutine test_s_effective_m05
 


### PR DESCRIPTION
## Summary

- Recompute the diagonal dipole-dipole contribution with the `kdmp5`
  damping exponent.
- Add a numerical stress regression test using distinct `kdmp3` and
  `kdmp5` values.

## Background

In `get_amat_sdq_dir_3d`, the temporary variable `tmp` contains the
charge-dipole damping term

```fortran
fdmp3 * g3 + e1
```

and was subsequently reused for the diagonal dipole-dipole matrix
elements. Those elements require the inverse-quintic damping exponent
and therefore have to use

```fortran
fdmp5 * g3 + e1
```

instead. The previous result was only accidentally correct when
`kdmp3` and `kdmp5` were equal. The off-diagonal dipole-dipole and
quadrupole terms already used `fdmp5`.

The added regression test assigns different values to both exponents,
so that the numerical stress check detects this mismatch.

## Testing

- `ctest --test-dir build -R coulomb-multipole --output-on-failure`
- Full local CTest suite shows no additional failures compared with
  unchanged `main` (`86/91` in both cases; the remaining five local
  C-API/test-drive failures are unrelated to this change).
